### PR TITLE
Changed from bolt to bbolt and added public methods in jobstore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/scalingdata/wmi v0.0.0-20170503153122-6f1e40b5b7f3 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	go.etcd.io/bbolt v1.3.4
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+go.etcd.io/bbolt v1.3.4 h1:hi1bXHMVrlQh6WwxAy+qZCV/SYIlqo+Ushwdpa4tAKg=
+go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -251,6 +253,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qd
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f h1:25KHgbfyiSm6vwQLbM3zZIe1v9p/3ea4Rz+nnM5K/i4=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/jobtracker/simpletracker/jobstore.go
+++ b/pkg/jobtracker/simpletracker/jobstore.go
@@ -10,6 +10,7 @@ import (
 
 // JobStore is an internal storage for jobs and job templates
 // processed by the job tracker. Jobs are stored until Reap().
+// Locking must be done externally.
 type JobStore struct {
 	// jobids contains all known jobs in the system until they are reaped (Reap())
 	// these are jobs, not array jobs and can be in format "1.1" or "1"
@@ -149,4 +150,20 @@ func (js *JobStore) GetPID(jobid string) (int, error) {
 		}
 	}
 	return -1, errors.New("TaskID not found in job array")
+}
+
+// GetJobIDs returns the IDs of all jobs.
+func (js *JobStore) GetJobIDs() []string {
+	tmp := make([]string, len(js.jobids), len(js.jobids))
+	copy(tmp, js.jobids)
+	return tmp
+}
+
+// GetArrayJobTaskIDs returns the IDs of all tasks of a job array.
+func (js *JobStore) GetArrayJobTaskIDs(arrayjobID string) []string {
+	jobids := make([]string, 0, len(js.jobs[arrayjobID]))
+	for _, job := range js.jobs[arrayjobID] {
+		jobids = append(jobids, fmt.Sprintf("%s.%d", arrayjobID, job.TaskID))
+	}
+	return jobids
 }

--- a/pkg/jobtracker/simpletracker/jobstore_test.go
+++ b/pkg/jobtracker/simpletracker/jobstore_test.go
@@ -143,6 +143,34 @@ var _ = Describe("Jobstore", func() {
 			Ω(err).ShouldNot(BeNil())
 		})
 
+		It("should return the task IDs of an array job", func() {
+			store := NewJobStore()
+			Ω(store).ShouldNot(BeNil())
+			store.SaveArrayJob("112",
+				[]int{0, 0, 0}, // no pid
+				drmaa2interface.JobTemplate{RemoteCommand: "rc"},
+				1, 3, 1)
+			tasks := store.GetArrayJobTaskIDs("112")
+			Ω(len(tasks)).To(BeNumerically("==", 3))
+			Ω(tasks[0]).To(Equal("112.1"))
+			Ω(tasks[1]).To(Equal("112.2"))
+			Ω(tasks[2]).To(Equal("112.3"))
+		})
+
+		It("should return the task IDs of an array job as job IDs", func() {
+			store := NewJobStore()
+			Ω(store).ShouldNot(BeNil())
+			store.SaveArrayJob("112",
+				[]int{0, 0, 0}, // no pid
+				drmaa2interface.JobTemplate{RemoteCommand: "rc"},
+				1, 3, 1)
+			tasks := store.GetJobIDs()
+			Ω(len(tasks)).To(BeNumerically("==", 3))
+			Ω(tasks[0]).To(Equal("112.1"))
+			Ω(tasks[1]).To(Equal("112.2"))
+			Ω(tasks[2]).To(Equal("112.3"))
+		})
+
 	})
 
 })

--- a/pkg/storage/boltstore/boltstore.go
+++ b/pkg/storage/boltstore/boltstore.go
@@ -2,8 +2,8 @@ package boltstore
 
 import (
 	"errors"
-	"github.com/boltdb/bolt"
 	"github.com/dgruber/drmaa2os/pkg/storage"
+	bolt "go.etcd.io/bbolt"
 	"log"
 	"time"
 )


### PR DESCRIPTION
The bolt project is not active anymore and seems to have race-conditions. Updated to bbolt which is maintained. Added public methods in job store so that it can be used by other job tracker implementations if needed.