### PR TITLE
Decoupled JobTracker implementation to simplify dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ _DRMAA2 for OS processes and more_
 [![CircleCI](https://circleci.com/gh/dgruber/drmaa2os.svg?style=svg)](https://circleci.com/gh/dgruber/drmaa2os)
 [![codecov](https://codecov.io/gh/dgruber/drmaa2os/branch/master/graph/badge.svg)](https://codecov.io/gh/dgruber/drmaa2os)
 
+> _Update_: The Go DRMAA2 interface and the implementation based on the JobTracker
+> interface are now decoupled. In order to use a specific backend, like Docker,
+> the package providing the JobTracker implementation needs to be imported so
+> that the init() method is called for registering at the DRMAA2 implementation.
+> 
+> Like when using the Docker backend:
+> 
+> ```
+> 	_ "github.com/dgruber/drmaa2os/pkg/jobtracker/dockertracker"
+> ```
+
+
 This is a Go API based on an open standard ([Open Grid Forum DRMAA2](https://www.ogf.org/documents/GFD.231.pdf)) for submitting and
 supervising workloads running in operating system processes, containers, PODs, tasks, or HPC batch jobs.
 
@@ -38,6 +50,11 @@ Following example demonstrates how a job running as OS process can be executed. 
 Note that at this point in time only _JobSessions_ are implemented.
 
 ```go
+    import (
+        "github.com/dgruber/drmaa2os
+        _ "github.com/dgruber/drmaa2os/pkg/jobtracker/simpletracker"
+    )
+
 	sm, err := drmaa2os.NewDefaultSessionManager("testdb.db")
 	if err != nil {
 		panic(err)
@@ -90,6 +107,12 @@ is created.
  Use DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default."
 
 ```go
+
+    import (
+        "github.com/dgruber/drmaa2os
+        _ "github.com/dgruber/drmaa2os/pkg/jobtracker/dockertracker"
+    )
+
 	sm, err := drmaa2os.NewDockerSessionManager("testdb.db")
 	if err != nil {
 		panic(err)
@@ -119,6 +142,12 @@ is created.
 ### Kubernetes
 
 ```go
+
+    import (
+        "github.com/dgruber/drmaa2os
+        _ "github.com/dgruber/drmaa2os/pkg/jobtracker/kubernetestracker"
+    )
+
 	sm, err := drmaa2os.NewKubernetesSessionManager("testdb.db")
 	if err != nil {
 		panic(err)
@@ -153,6 +182,12 @@ be set to the application GUID which is the source of the container image
 of the task.
 
 ```go
+
+    import (
+        "github.com/dgruber/drmaa2os
+        _ "github.com/dgruber/drmaa2os/pkg/jobtracker/cftracker"
+    )
+
 	sm, err := drmaa2os.NewCloudFoundrySessionManager("api.run.pivotal.io", "user", "password", "test.db")
 	if err != nil {
 		panic(err)
@@ -186,6 +221,12 @@ The container images can be provided in any form (like pointing to file or shub)
 required to be set as _JobCategory_ for each job.
 
 ```go
+
+    import (
+        "github.com/dgruber/drmaa2os
+        _ "github.com/dgruber/drmaa2os/pkg/jobtracker/singularity"
+    )
+
 	sm, err := drmaa2os.NewSingularitySessionManager("testdb.db")
 	if err != nil {
 		panic(err)
@@ -212,7 +253,5 @@ required to be set as _JobCategory_ for each job.
 	js.Close()
 	sm.DestroyJobSession("jobsession")
 ```
-
-
 
 

--- a/examples/kubernetes/kubernetes.go
+++ b/examples/kubernetes/kubernetes.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/dgruber/drmaa2interface"
 	"github.com/dgruber/drmaa2os"
-	"time"
+	_ "github.com/dgruber/drmaa2os/pkg/jobtracker/kubernetestracker"
 )
 
 func createJobSession(sm drmaa2interface.SessionManager) drmaa2interface.JobSession {
@@ -27,7 +29,7 @@ func print(ji drmaa2interface.JobInfo) {
 }
 
 func main() {
-	sm, err := drmaa2os.NewKubernetesSessionManager("testdb.db")
+	sm, err := drmaa2os.NewKubernetesSessionManager(nil, "testdb.db")
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dgruber/drmaa2os
 
-go 1.13
+go 1.14
 
 replace (
 	k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a

--- a/jobsession.go
+++ b/jobsession.go
@@ -1,10 +1,11 @@
 package drmaa2os
 
 import (
+	"time"
+
 	"github.com/dgruber/drmaa2interface"
 	"github.com/dgruber/drmaa2os/pkg/d2hlp"
 	"github.com/dgruber/drmaa2os/pkg/jobtracker"
-	"time"
 )
 
 // JobSession instance acts as container for job instances controlled
@@ -52,7 +53,7 @@ func (js *JobSession) GetSessionName() (string, error) {
 // can be used for the jobCategory attribute in a JobTemplate instance.
 func (js *JobSession) GetJobCategories() ([]string, error) {
 	var lastError error
-	var jobCategories []string
+	jobCategories := make([]string, 0, 16)
 	for _, tracker := range js.tracker {
 		cat, err := tracker.ListJobCategories()
 		if err != nil {

--- a/pkg/jobtracker/dockertracker/dockertracker.go
+++ b/pkg/jobtracker/dockertracker/dockertracker.go
@@ -2,16 +2,36 @@ package dockertracker
 
 import (
 	"errors"
+
 	"github.com/dgruber/drmaa2interface"
+	"github.com/dgruber/drmaa2os"
 	"github.com/dgruber/drmaa2os/pkg/helper"
+	"github.com/dgruber/drmaa2os/pkg/jobtracker"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 
-	"golang.org/x/net/context"
 	"strings"
 	"time"
+
+	"golang.org/x/net/context"
 )
+
+// init registers the Docker tracker at the SessionManager
+func init() {
+	drmaa2os.RegisterJobTracker(drmaa2os.DockerSession, NewAllocator())
+}
+
+type allocator struct{}
+
+func NewAllocator() *allocator {
+	return &allocator{}
+}
+
+// New is called by the SessionManager when a new JobSession is allocated.
+func (a *allocator) New(jobSessionName string, jobTrackerInitParams interface{}) (jobtracker.JobTracker, error) {
+	return New(jobSessionName)
+}
 
 type DockerTracker struct {
 	jobsession string

--- a/pkg/jobtracker/jobtracker.go
+++ b/pkg/jobtracker/jobtracker.go
@@ -1,9 +1,19 @@
 package jobtracker
 
 import (
-	"github.com/dgruber/drmaa2interface"
 	"time"
+
+	"github.com/dgruber/drmaa2interface"
 )
+
+// Allocator contains all what is required to create a new JobTacker
+// instance. A JobTracker implementation needs to register the Allocator
+// implementation in its init method where it needs to call RegisterJobTracker()
+// of the drmaa2os SessionManager. The jobTrackerInitParams are an optional
+// way for parameterize the JobTracker creation method.
+type Allocator interface {
+	New(jobSessionName string, jobTrackerInitParams interface{}) (JobTracker, error)
+}
 
 type JobTracker interface {
 	ListJobs() ([]string, error)

--- a/pkg/jobtracker/simpletracker/simpletracker.go
+++ b/pkg/jobtracker/simpletracker/simpletracker.go
@@ -3,11 +3,30 @@ package simpletracker
 import (
 	"errors"
 	"fmt"
-	"github.com/dgruber/drmaa2interface"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dgruber/drmaa2interface"
+	"github.com/dgruber/drmaa2os"
+	"github.com/dgruber/drmaa2os/pkg/jobtracker"
 )
+
+// init registers the process tracker at the SessionManager
+func init() {
+	drmaa2os.RegisterJobTracker(drmaa2os.DefaultSession, NewAllocator())
+}
+
+type allocator struct{}
+
+func NewAllocator() *allocator {
+	return &allocator{}
+}
+
+// New is called by the SessionManager when a new JobSession is allocated.
+func (a *allocator) New(jobSessionName string, jobTrackerInitParams interface{}) (jobtracker.JobTracker, error) {
+	return New(jobSessionName), nil
+}
 
 // JobTracker implements the JobTracker interface and treats
 // jobs as OS processes.

--- a/pkg/jobtracker/singularity/singularity.go
+++ b/pkg/jobtracker/singularity/singularity.go
@@ -6,8 +6,26 @@ import (
 	"time"
 
 	"github.com/dgruber/drmaa2interface"
+	"github.com/dgruber/drmaa2os"
+	"github.com/dgruber/drmaa2os/pkg/jobtracker"
 	"github.com/dgruber/drmaa2os/pkg/jobtracker/simpletracker"
 )
+
+// init registers the singularity tracker at the SessionManager
+func init() {
+	drmaa2os.RegisterJobTracker(drmaa2os.SingularitySession, NewAllocator())
+}
+
+func NewAllocator() *allocator {
+	return &allocator{}
+}
+
+type allocator struct{}
+
+// New is called by the SessionManager when a new JobSession is allocated.
+func (a *allocator) New(jobSessionName string, jobTrackerInitParams interface{}) (jobtracker.JobTracker, error) {
+	return New(jobSessionName)
+}
 
 // Tracker tracks singularity container.
 type Tracker struct {

--- a/pkg/jobtracker/slurmcli/tracker.go
+++ b/pkg/jobtracker/slurmcli/tracker.go
@@ -5,9 +5,25 @@ import (
 	"time"
 
 	"github.com/dgruber/drmaa2interface"
+	"github.com/dgruber/drmaa2os"
 	"github.com/dgruber/drmaa2os/pkg/helper"
+	"github.com/dgruber/drmaa2os/pkg/jobtracker"
 	"github.com/dgruber/drmaa2os/pkg/jobtracker/simpletracker"
 )
+
+// init registers the slurm tracker at the SessionManager
+func init() {
+	var a allocator
+	drmaa2os.RegisterJobTracker(drmaa2os.SlurmSession, &a)
+}
+
+type allocator struct{}
+
+// New is called by the SessionManager when a new JobSession is allocated.
+func (a *allocator) New(jobSessionName string, jobTrackerInitParams interface{}) (jobtracker.JobTracker, error) {
+	return New(jobSessionName, NewSlurm("sbatch",
+		"squeue", "scontrol", "scancel", "sacct", true))
+}
 
 // Tracker implements the JobTracker interface by calling
 // the slurm command line.

--- a/sessionmanager.go
+++ b/sessionmanager.go
@@ -1,11 +1,15 @@
 package drmaa2os
 
 import (
-	"code.cloudfoundry.org/lager"
 	"errors"
+
+	"code.cloudfoundry.org/lager"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/dgruber/drmaa2interface"
 	"github.com/dgruber/drmaa2os/pkg/jobtracker"
-	"github.com/dgruber/drmaa2os/pkg/jobtracker/slurmcli"
+
+	//	"github.com/dgruber/drmaa2os/pkg/jobtracker/slurmcli"
 	"github.com/dgruber/drmaa2os/pkg/storage"
 )
 
@@ -25,17 +29,47 @@ const (
 	SingularitySession
 	// SlurmSession manages slurm jobs
 	SlurmSession
+	// DRMAASession uses libdrmaa.so (v1) for managing job
+	DRMAASession
 )
+
+func init() {
+	// initialize job tracker registration map
+	atomicTrackers.Store(make(map[SessionType]jobtracker.Allocator))
+}
+
+// RegisterJobTracker registers a JobTracker implementation at session manager
+// so that it can be used. This is done in the init() method of the JobTracker
+// implementation. That means the application which wants to use a specific JobTracker
+// needs to import the JobTracker implementation package with _.
+//
+// Like when Docker needs to be used as job management backend:
+//
+// import _ "github.com/dgruber/drmaa2os/pkg/jobtracker/pkg/dockertracker"
+//
+// When multiple backends to be used, all of them needs to be imported so
+// that they are registered in the main application.
+func RegisterJobTracker(sessionType SessionType, tracker jobtracker.Allocator) {
+	trackerMutex.Lock()
+	jtMap := atomicTrackers.Load().(map[SessionType]jobtracker.Allocator)
+	if jtMap == nil {
+		jtMap = make(map[SessionType]jobtracker.Allocator)
+	}
+	jtMap[sessionType] = tracker
+	atomicTrackers.Store(jtMap)
+	trackerMutex.Unlock()
+}
 
 // SessionManager allows to create, list, and destroy job, reserveration,
 // and monitoring sessions. It also returns holds basic information about
 // the resource manager and its capabilities.
 type SessionManager struct {
-	store       storage.Storer
-	log         lager.Logger
-	sessionType SessionType
-	cf          cfContact
-	slurm       *slurmcli.Slurm
+	store                  storage.Storer
+	log                    lager.Logger
+	sessionType            SessionType
+	jobTrackerCreateParams interface{}
+	// cf          cfContact
+	//slurm       *slurmcli.Slurm
 }
 
 // NewDefaultSessionManager creates a SessionManager which starts jobs
@@ -65,18 +99,28 @@ func NewCloudFoundrySessionManager(addr, username, password, dbpath string) (*Se
 	if err != nil {
 		return sm, err
 	}
-	sm.cf = cfContact{
-		addr:     addr,
-		username: username,
-		password: password,
-	}
+	// specific parameters for Cloud Foundry
+	sm.jobTrackerCreateParams = []string{addr, username, password}
+	/*
+		sm.cf = cfContact{
+			addr:     addr,
+			username: username,
+			password: password,
+		}
+	*/
 	return sm, nil
 }
 
 // NewKubernetesSessionManager creates a new session manager which uses
 // Kubernetes tasks as execution backend for jobs.
-func NewKubernetesSessionManager(dbpath string) (*SessionManager, error) {
-	return makeSessionManager(dbpath, KubernetesSession)
+func NewKubernetesSessionManager(cs *kubernetes.Clientset, dbpath string) (*SessionManager, error) {
+	sm, err := makeSessionManager(dbpath, KubernetesSession)
+	if err != nil {
+		return sm, err
+	}
+	// when a job session is created is requires a kubernetes clientset
+	sm.jobTrackerCreateParams = cs
+	return sm, nil
 }
 
 // NewSlurmSessionManager creates a new session manager which wraps the
@@ -85,12 +129,28 @@ func NewSlurmSessionManager(dbpath string) (*SessionManager, error) {
 	return makeSessionManager(dbpath, SlurmSession)
 }
 
+// NewDRMAASessionManager creates a new session manager which wraps the
+// libdrmaa.so provided by different workloadmanagers.
+func NewDRMAASessionManager(dbpath string) (*SessionManager, error) {
+	// TODO check if registered?
+	return makeSessionManager(dbpath, DRMAASession)
+}
+
 // CreateJobSession creates a new JobSession for managing jobs.
 func (sm *SessionManager) CreateJobSession(name, contact string) (drmaa2interface.JobSession, error) {
 	if err := sm.create(storage.JobSessionType, name, contact); err != nil {
 		return nil, err
 	}
-	jt, err := sm.newJobTracker(name)
+	/*
+		jt, err := sm.newJobTracker(name)
+		if err != nil {
+			return nil, err
+		}
+	*/
+	// allocate a registered job tracker - registration happens
+	// when the package is imported in the init method of the
+	// JobTracker implementation package
+	jt, err := sm.newRegisteredJobTracker(name, sm.jobTrackerCreateParams)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +174,7 @@ func (sm *SessionManager) OpenJobSession(name string) (drmaa2interface.JobSessio
 	if exists := sm.store.Exists(storage.JobSessionType, name); !exists {
 		return nil, errors.New("JobSession does not exist")
 	}
-	jt, err := sm.newJobTracker(name)
+	jt, err := sm.newRegisteredJobTracker(name, sm.jobTrackerCreateParams)
 	if err != nil {
 		return nil, err
 	}

--- a/sessionmanager_test.go
+++ b/sessionmanager_test.go
@@ -1,24 +1,20 @@
-package drmaa2os
+package drmaa2os_test
 
 import (
-	"code.cloudfoundry.org/lager"
 	"github.com/dgruber/drmaa2interface"
-	"github.com/dgruber/drmaa2os/pkg/storage/boltstore"
+	"github.com/dgruber/drmaa2os"
+
+	"os"
+
+	// test with process tracker
+	_ "github.com/dgruber/drmaa2os/pkg/jobtracker/dockertracker"
+	_ "github.com/dgruber/drmaa2os/pkg/jobtracker/simpletracker"
+	_ "github.com/dgruber/drmaa2os/pkg/jobtracker/singularity"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"os"
 )
 
 const smtempdb string = "drmaa2ostest.db"
-
-func createSessionManager() drmaa2interface.SessionManager {
-	os.Remove(smtempdb)
-	s := boltstore.NewBoltStore(smtempdb)
-	s.Init()
-	l := lager.NewLogger("drmaa2ostest")
-	l.RegisterSink(lager.NewWriterSink(os.Stdout, lager.INFO))
-	return &SessionManager{store: s, log: l}
-}
 
 var _ = Describe("Sessionmanager", func() {
 
@@ -28,7 +24,8 @@ var _ = Describe("Sessionmanager", func() {
 
 	BeforeEach(func() {
 		os.Remove("drmaa2ostest")
-		sm, _ = NewDefaultSessionManager("drmaa2ostest")
+		sm, _ = drmaa2os.NewDefaultSessionManager("drmaa2ostest")
+		//sm, _ = drmaa2os.NewDockerSessionManager("drmaa2ostest")
 	})
 
 	Describe("Create and Destroy Job Session", func() {
@@ -221,21 +218,21 @@ var _ = Describe("Sessionmanager", func() {
 			rs, err := sm.CreateReservationSession("reservationSession", "")
 			Ω(rs).Should(BeNil())
 			Ω(err).ShouldNot(BeNil())
-			Ω(err).Should(Equal(ErrorUnsupportedOperation))
+			Ω(err).Should(Equal(drmaa2os.ErrorUnsupportedOperation))
 
 			rs, err = sm.OpenReservationSession("reservationSession")
 			Ω(rs).Should(BeNil())
 			Ω(err).ShouldNot(BeNil())
-			Ω(err).Should(Equal(ErrorUnsupportedOperation))
+			Ω(err).Should(Equal(drmaa2os.ErrorUnsupportedOperation))
 
 			err = sm.DestroyReservationSession("reservationSession")
 			Ω(err).ShouldNot(BeNil())
-			Ω(err).Should(Equal(ErrorUnsupportedOperation))
+			Ω(err).Should(Equal(drmaa2os.ErrorUnsupportedOperation))
 
 			names, err := sm.GetReservationSessionNames()
 			Ω(names).Should(BeNil())
 			Ω(err).ShouldNot(BeNil())
-			Ω(err).Should(Equal(ErrorUnsupportedOperation))
+			Ω(err).Should(Equal(drmaa2os.ErrorUnsupportedOperation))
 		})
 
 	})


### PR DESCRIPTION
When using the drmaa2os package there was always a dependency to Kubernetes, Docker, and other 3rd party libraries. That causes many issues, like compile time, large binaries, dependency issues during compile time, etc. 

Now the SessionManager does not import any of the JobTracker implementations. This must be done in the main application using drmaa2os package by importing the JobTracker without using it ( _). Importing causes the init() method of the JobTracker to be called which registers itself at JobTracker. 
