### PR TITLE
Add WorkingDir from JobTemplate

### DIFF
--- a/pkg/jobtracker/dockertracker/convert.go
+++ b/pkg/jobtracker/dockertracker/convert.go
@@ -73,6 +73,10 @@ func jobTemplateToContainerConfig(jobsession string, jt drmaa2interface.JobTempl
 		cc.Cmd = cmdSlice
 	}
 
+	if jt.WorkingDirectory != "" {
+		cc.WorkingDir = jt.WorkingDirectory
+	}
+
 	cc.Env = setEnv(jt.JobEnvironment)
 	// Docker specific settings in the extensions
 	if jt.ExtensionList != nil {

--- a/pkg/jobtracker/dockertracker/job.go
+++ b/pkg/jobtracker/dockertracker/job.go
@@ -2,13 +2,14 @@ package dockertracker
 
 import (
 	"fmt"
+	"io"
+	"os"
+
 	"github.com/dgruber/drmaa2interface"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"golang.org/x/net/context"
-	"io"
-	"os"
 )
 
 func runJob(jobsession string, cli *client.Client, jt drmaa2interface.JobTemplate) (string, error) {


### PR DESCRIPTION
The `JobTemplate` has a field, but it was never able to reach the docker API.