### PR TITLE
Keep libdrmaa jobs persistent and use stored contact string when opening job session #24

### DIFF
--- a/examples/libdrmaasessions/Dockerfile
+++ b/examples/libdrmaasessions/Dockerfile
@@ -1,0 +1,21 @@
+FROM drmaa/gridengine
+
+RUN yum install -y wget tar git gcc
+
+RUN export VERSION=1.16 OS=linux ARCH=amd64 && \
+  wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
+  tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
+  rm go$VERSION.$OS-$ARCH.tar.gz
+
+ENV GOPATH /go
+ENV PATH /usr/local/go/bin:${PATH}:${GOPATH}/bin
+ENV PATH ${PATH}:/opt/sge/include
+
+RUN go get github.com/dgruber/drmaa2interface
+RUN mkdir -p /go/src/github.com/dgruber/drmaa2os/examples/libdrmaasessions
+ADD . /go/src/github.com/dgruber/drmaa2os/examples/libdrmaasessions
+
+ADD entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+

--- a/examples/libdrmaasessions/entrypoint.sh
+++ b/examples/libdrmaasessions/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+cd /opt/sge
+./install.sh
+
+source /opt/sge/default/common/settings.sh
+
+export LD_LIBRARY_PATH=$SGE_ROOT/lib/lx-amd64
+export PATH=$PATH:/opt/sge/include
+
+export CGO_LDFLAGS="-L$SGE_ROOT/lib/lx-amd64/"
+export CGO_CFLAGS="-DSOG -I$SGE_ROOT/include"
+
+# run tests
+
+cd /go/src/github.com/dgruber/drmaa2os/examples/libdrmaasessions
+go get github.com/dgruber/drmaa2os@issue_24
+go get github.com/dgruber/drmaa2os/pkg/jobtracker/libdrmaa@issue_24
+
+#go mod download
+go build
+
+./libdrmaasessions
+
+exec "$@"

--- a/examples/libdrmaasessions/go.mod
+++ b/examples/libdrmaasessions/go.mod
@@ -1,0 +1,9 @@
+module github.com/dgruber/drmaa2os/examples/libdrmaasessions
+
+go 1.16
+
+require (
+	github.com/dgruber/drmaa2interface v1.0.2
+	github.com/dgruber/drmaa2os v0.3.12
+	github.com/dgruber/drmaa2os/pkg/jobtracker/libdrmaa v0.0.0-20210902062944-2162eb3a99c4
+)

--- a/examples/libdrmaasessions/libdrmaasessions.go
+++ b/examples/libdrmaasessions/libdrmaasessions.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dgruber/drmaa2interface"
+	"github.com/dgruber/drmaa2os"
+	"github.com/dgruber/drmaa2os/pkg/jobtracker/libdrmaa"
+)
+
+func main() {
+	params := libdrmaa.LibDRMAASessionParams{
+		ContactString:           "",
+		UsePersistentJobStorage: true,
+		DBFilePath:              "testdbjobs.db",
+	}
+	sm, err := drmaa2os.NewLibDRMAASessionManagerWithParams(params, "testdb.db")
+	if err != nil {
+		panic(err)
+	}
+
+	var contact string
+	if len(os.Args) == 2 {
+		contact = os.Args[1]
+		fmt.Printf("using contact string %s\n", contact)
+	}
+
+	js, err := sm.CreateJobSession("jobsession6", contact)
+	if err != nil {
+		fmt.Printf("failed creating job session, trying to open it\n")
+		js, err = sm.OpenJobSession("jobsession6")
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		contact, err := js.GetContact()
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("session has contact string %s\n", contact)
+	}
+	defer js.Close()
+
+	jobinfo := drmaa2interface.CreateJobInfo()
+	jobs, err := js.GetJobs(jobinfo)
+	if err != nil {
+		panic(err)
+	}
+	for _, job := range jobs {
+		fmt.Printf("found job %s\n", job.GetID())
+	}
+
+	job, err := js.RunJob(drmaa2interface.JobTemplate{
+		JobName:       "job1",
+		RemoteCommand: "/bin/sleep",
+		Args:          []string{"100"},
+	})
+	if err != nil {
+		fmt.Printf("job submission failed: %v\n", err)
+		js.Close()
+		os.Exit(1)
+	}
+	fmt.Printf("job submitted with ID %s\n", job.GetID())
+}

--- a/examples/libdrmaasessions/test.sh
+++ b/examples/libdrmaasessions/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker build -t drmaa/drmaa2oslibdrmaaexample:latest .
+docker run --rm -it drmaa/drmaa2oslibdrmaaexample:latest /bin/bash
+
+

--- a/jobsession.go
+++ b/jobsession.go
@@ -2,7 +2,6 @@ package drmaa2os
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/dgruber/drmaa2interface"

--- a/jobsession.go
+++ b/jobsession.go
@@ -96,7 +96,8 @@ func (js *JobSession) GetJobs(filter drmaa2interface.JobInfo) ([]drmaa2interface
 		}
 		for _, jobid := range jobs {
 			if jinfo, err := tracker.JobInfo(jobid); err != nil {
-				fmt.Printf("failed getting job info for job %s: %v", jobid, err)
+				// TODO add as exited with info from jobsession DB
+				//fmt.Printf("failed getting job info for job %s: %v\n", jobid, err)
 				continue
 			} else {
 				if d2hlp.JobInfoMatches(jinfo, filter) {

--- a/jobsession.go
+++ b/jobsession.go
@@ -1,6 +1,8 @@
 package drmaa2os
 
 import (
+	"fmt"
+	"log"
 	"time"
 
 	"github.com/dgruber/drmaa2interface"
@@ -14,6 +16,9 @@ import (
 type JobSession struct {
 	name    string
 	tracker []jobtracker.JobTracker
+	// libdrmaa stores newly created internal job session name
+	// inside contact string
+	contact string
 }
 
 // Close MUST perform the necessary action to disengage from the DRM system.
@@ -39,7 +44,12 @@ func (js *JobSession) Close() error {
 // value was originally provided, the default contact string from the
 // implementation MUST be returned.
 func (js *JobSession) GetContact() (string, error) {
-	return "", nil
+	if len(js.tracker) >= 1 {
+		if cs, ok := js.tracker[0].(jobtracker.ContactStringer); ok {
+			return cs.Contact()
+		}
+	}
+	return "not implemented", nil
 }
 
 // GetSessionName reports the session name, a value that resulted from the
@@ -82,10 +92,12 @@ func (js *JobSession) GetJobs(filter drmaa2interface.JobInfo) ([]drmaa2interface
 	for _, tracker := range js.tracker {
 		jobs, err := tracker.ListJobs()
 		if err != nil {
+			fmt.Printf("error listings jobs: %v", err)
 			return nil, err
 		}
 		for _, jobid := range jobs {
 			if jinfo, err := tracker.JobInfo(jobid); err != nil {
+				fmt.Printf("failed getting job info for job %s: %v", jobid, err)
 				continue
 			} else {
 				if d2hlp.JobInfoMatches(jinfo, filter) {

--- a/pkg/jobtracker/dockertracker/dockertracker_test.go
+++ b/pkg/jobtracker/dockertracker/dockertracker_test.go
@@ -7,10 +7,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"fmt"
-	"github.com/dgruber/drmaa2interface"
 	"io/ioutil"
 	"os"
 	"time"
+
+	"github.com/dgruber/drmaa2interface"
 )
 
 var _ = Describe("Dockertracker", func() {
@@ -59,7 +60,7 @@ var _ = Describe("Dockertracker", func() {
 			jt = drmaa2interface.JobTemplate{
 				RemoteCommand:  "/bin/sleep",
 				Args:           []string{"1"},
-				JobCategory:    "golang",
+				JobCategory:    "alpine",
 				StageInFiles:   map[string]string{"README.md": "/README.md"},
 				JobEnvironment: map[string]string{"test": "value"},
 			}
@@ -90,7 +91,7 @@ var _ = Describe("Dockertracker", func() {
 		})
 
 		It("should print output to file", func() {
-			jt.RemoteCommand = "/bin/bash"
+			jt.RemoteCommand = "/bin/sh"
 			jt.Args = []string{"-c", `echo prost`}
 			jt.OutputPath = "./testfile"
 
@@ -107,7 +108,7 @@ var _ = Describe("Dockertracker", func() {
 		})
 
 		It("should print stderr to file", func() {
-			jt.RemoteCommand = "/bin/bash"
+			jt.RemoteCommand = "/bin/sh"
 			jt.Args = []string{"-c", `date illegal`}
 			jt.ErrorPath = "./errtestfile"
 
@@ -128,7 +129,7 @@ var _ = Describe("Dockertracker", func() {
 		jt := drmaa2interface.JobTemplate{
 			RemoteCommand: "/bin/sleep",
 			Args:          []string{"1"},
-			JobCategory:   "golang",
+			JobCategory:   "alpine",
 		}
 
 		var tracker *DockerTracker
@@ -153,7 +154,7 @@ var _ = Describe("Dockertracker", func() {
 		jt := drmaa2interface.JobTemplate{
 			RemoteCommand: "/bin/sleep",
 			Args:          []string{"1"},
-			JobCategory:   "golang",
+			JobCategory:   "alpine",
 		}
 
 		var tracker *DockerTracker
@@ -237,7 +238,7 @@ var _ = Describe("Dockertracker", func() {
 			jt := drmaa2interface.JobTemplate{
 				RemoteCommand: "/bin/sleep",
 				Args:          []string{"1"},
-				JobCategory:   "golang",
+				JobCategory:   "alpine",
 			}
 
 			jobid, err := tracker.AddJob(jt)

--- a/pkg/jobtracker/jobtracker.go
+++ b/pkg/jobtracker/jobtracker.go
@@ -34,3 +34,9 @@ type JobTracker interface {
 	DeleteJob(jobid string) error
 	ListJobCategories() ([]string, error)
 }
+
+// ContactStringer is a JobTracker which offers the Contact() method which
+// returns the contact string. Used in the DRMAA1 JobTracker.
+type ContactStringer interface {
+	Contact() (string, error)
+}

--- a/pkg/jobtracker/libdrmaa/Dockerfile
+++ b/pkg/jobtracker/libdrmaa/Dockerfile
@@ -2,7 +2,7 @@ FROM drmaa/gridengine
 
 RUN yum install -y wget tar git gcc
 
-RUN export VERSION=1.14 OS=linux ARCH=amd64 && \
+RUN export VERSION=1.16 OS=linux ARCH=amd64 && \
   wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
   tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
   rm go$VERSION.$OS-$ARCH.tar.gz

--- a/pkg/jobtracker/libdrmaa/go.mod
+++ b/pkg/jobtracker/libdrmaa/go.mod
@@ -1,11 +1,13 @@
 module github.com/dgruber/drmaa2os/pkg/jobtracker/libdrmaa
 
-go 1.14
+go 1.16
+
+replace github.com/dgruber/drmaa2os/pkg/jobtracker/simpletracker => ../simpletracker
 
 require (
 	github.com/dgruber/drmaa v1.0.0
-	github.com/dgruber/drmaa2interface v1.0.0
-	github.com/dgruber/drmaa2os v0.3.0-beta2
-	github.com/onsi/ginkgo v1.12.3
-	github.com/onsi/gomega v1.10.1
+	github.com/dgruber/drmaa2interface v1.0.2
+	github.com/dgruber/drmaa2os v0.3.12
+	github.com/onsi/ginkgo v1.16.4
+	github.com/onsi/gomega v1.16.0
 )

--- a/pkg/jobtracker/libdrmaa/tracker.go
+++ b/pkg/jobtracker/libdrmaa/tracker.go
@@ -76,7 +76,7 @@ func NewDRMAATrackerWithParams(params interface{}) (*DRMAATracker, error) {
 		return NewDRMAATracker()
 	}
 
-	drmaaParams, ok := params.(*LibDRMAASessionParams)
+	drmaaParams, ok := params.(LibDRMAASessionParams)
 	if ok == false {
 		return nil, fmt.Errorf("can not initialized DRMAA job tracker as params is not of type LibDRMAASessionParams")
 	}
@@ -282,7 +282,7 @@ func (t *DRMAATracker) ListJobCategories() ([]string, error) {
 	return []string{}, nil
 }
 
-// Contact() returns the contact string. Implements GetContactStringer interface.
+// Contact() returns the contact string. Implements ContactStringer interface.
 // Used for getting the job session name of DRMAA1 out of Grid Engine.
 func (t *DRMAATracker) Contact() (string, error) {
 	return drmaa.GetContact()

--- a/pkg/jobtracker/libdrmaa/tracker.go
+++ b/pkg/jobtracker/libdrmaa/tracker.go
@@ -33,6 +33,9 @@ func (a *allocator) New(jobSessionName string, jobTrackerInitParams interface{})
 // LibDRMAASessionParams contains arguments which can be evaluated
 // during DRMAA2 job session creation.
 type LibDRMAASessionParams struct {
+	// ContactString is required also for opening job sessions
+	// hence do not change the name of ContactString as SessionManager
+	// depends on that
 	ContactString string
 }
 

--- a/pkg/jobtracker/libdrmaa/tracker_test.go
+++ b/pkg/jobtracker/libdrmaa/tracker_test.go
@@ -1,6 +1,7 @@
 package libdrmaa
 
 import (
+	"os"
 	"time"
 
 	"github.com/dgruber/drmaa2interface"
@@ -11,6 +12,29 @@ import (
 var _ = Describe("Tracker", func() {
 
 	var sleeperJob drmaa2interface.JobTemplate
+
+	getTempFile := func() string {
+		file, _ := os.CreateTemp("", "drmaatracketest")
+		name := file.Name()
+		file.Close()
+		return name
+	}
+
+	createTracker := func(standard bool) *DRMAATracker {
+		if standard {
+			standardTracker, err := NewDRMAATracker()
+			Expect(err).To(BeNil())
+			return standardTracker
+		}
+		params := LibDRMAASessionParams{
+			ContactString:           "",
+			UsePersistentJobStorage: true,
+			DBFilePath:              getTempFile(),
+		}
+		trackerWithParams, err := NewDRMAATrackerWithParams(&params)
+		Expect(err).To(BeNil())
+		return trackerWithParams
+	}
 
 	BeforeEach(func() {
 		sleeperJob = drmaa2interface.JobTemplate{
@@ -23,72 +47,78 @@ var _ = Describe("Tracker", func() {
 	Context("Basic workflow", func() {
 
 		It("should run a single job", func() {
-			d, err := NewDRMAATracker()
-			Expect(err).To(BeNil())
-			defer d.DestroySession()
-			Expect(d).NotTo(BeNil())
 
-			jobID, err := d.AddJob(sleeperJob)
-			Expect(err).To(BeNil())
-			Expect(jobID).NotTo(Equal(""))
+			// run test for each tracker instantiation
+			for _, standardTracker := range []bool{true, false} {
+				d := createTracker(standardTracker)
+				Expect(d).NotTo(BeNil())
 
-			err = d.Wait(jobID, time.Second*31, drmaa2interface.Done, drmaa2interface.Failed)
-			Expect(err).To(BeNil())
+				jobID, err := d.AddJob(sleeperJob)
+				Expect(err).To(BeNil())
+				Expect(jobID).NotTo(Equal(""))
 
-			state, substate, err := d.JobState(jobID)
-			Expect(err).To(BeNil())
-			Expect(substate).To(Equal(""))
-			Expect(state.String()).To(Equal(drmaa2interface.Done.String()))
-
-			jobs, err := d.ListJobs()
-			Expect(err).To(BeNil())
-			Expect(len(jobs)).To(BeNumerically("==", 1))
-			Expect(jobs[0]).To(Equal(jobID))
-
-			state, _, err = d.JobState(jobID)
-			Expect(err).To(BeNil())
-			Expect(state).To(Equal(drmaa2interface.Done))
-
-			jobInfo, err := d.JobInfo(jobID)
-			Expect(err).To(BeNil())
-			Expect(jobInfo.ID).To(Equal(jobID))
-			Expect(jobInfo.State).To(Equal(drmaa2interface.Done))
-		})
-
-		It("should run a job array", func() {
-			d, err := NewDRMAATracker()
-			Expect(err).To(BeNil())
-			defer d.DestroySession()
-			Expect(d).NotTo(BeNil())
-
-			arrayJobID, err := d.AddArrayJob(sleeperJob, 1, 10, 1, 0)
-			Expect(err).To(BeNil())
-			Expect(arrayJobID).NotTo(Equal(""))
-
-			ids, err := d.ListArrayJobs(arrayJobID)
-			Expect(err).To(BeNil())
-			Expect(len(ids)).To(BeNumerically("==", 10))
-			for _, id := range ids {
-				err = d.Wait(id, time.Second*31, drmaa2interface.Done, drmaa2interface.Failed)
+				err = d.Wait(jobID, time.Second*31, drmaa2interface.Done, drmaa2interface.Failed)
 				Expect(err).To(BeNil())
 
-				state, substate, err := d.JobState(id)
+				state, substate, err := d.JobState(jobID)
 				Expect(err).To(BeNil())
 				Expect(substate).To(Equal(""))
 				Expect(state.String()).To(Equal(drmaa2interface.Done.String()))
+
+				jobs, err := d.ListJobs()
+				Expect(err).To(BeNil())
+				Expect(len(jobs)).To(BeNumerically("==", 1))
+				Expect(jobs[0]).To(Equal(jobID))
+
+				state, _, err = d.JobState(jobID)
+				Expect(err).To(BeNil())
+				Expect(state).To(Equal(drmaa2interface.Done))
+
+				jobInfo, err := d.JobInfo(jobID)
+				Expect(err).To(BeNil())
+				Expect(jobInfo.ID).To(Equal(jobID))
+				Expect(jobInfo.State).To(Equal(drmaa2interface.Done))
+
+				d.DestroySession()
 			}
+		})
 
-			jobs, err := d.ListJobs()
-			Expect(err).To(BeNil())
-			Expect(len(jobs)).To(BeNumerically("==", 10))
+		It("should run a job array", func() {
+			for _, standardTracker := range []bool{true, false} {
+				d := createTracker(standardTracker)
+				Expect(d).NotTo(BeNil())
 
-			state, _, err := d.JobState(ids[9])
-			Expect(err).To(BeNil())
-			Expect(state).To(Equal(drmaa2interface.Done))
+				arrayJobID, err := d.AddArrayJob(sleeperJob, 1, 10, 1, 0)
+				Expect(err).To(BeNil())
+				Expect(arrayJobID).NotTo(Equal(""))
 
-			jobInfo, err := d.JobInfo(ids[9])
-			Expect(err).To(BeNil())
-			Expect(jobInfo.State).To(Equal(drmaa2interface.Done))
+				ids, err := d.ListArrayJobs(arrayJobID)
+				Expect(err).To(BeNil())
+				Expect(len(ids)).To(BeNumerically("==", 10))
+				for _, id := range ids {
+					err = d.Wait(id, time.Second*31, drmaa2interface.Done, drmaa2interface.Failed)
+					Expect(err).To(BeNil())
+
+					state, substate, err := d.JobState(id)
+					Expect(err).To(BeNil())
+					Expect(substate).To(Equal(""))
+					Expect(state.String()).To(Equal(drmaa2interface.Done.String()))
+				}
+
+				jobs, err := d.ListJobs()
+				Expect(err).To(BeNil())
+				Expect(len(jobs)).To(BeNumerically("==", 10))
+
+				state, _, err := d.JobState(ids[9])
+				Expect(err).To(BeNil())
+				Expect(state).To(Equal(drmaa2interface.Done))
+
+				jobInfo, err := d.JobInfo(ids[9])
+				Expect(err).To(BeNil())
+				Expect(jobInfo.State).To(Equal(drmaa2interface.Done))
+
+				d.DestroySession()
+			}
 		})
 
 	})
@@ -96,57 +126,61 @@ var _ = Describe("Tracker", func() {
 	Context("Failing jobs", func() {
 
 		It("should mark a job as done and show exit status when exit status != 0", func() {
-			d, err := NewDRMAATracker()
-			Expect(err).To(BeNil())
-			defer d.DestroySession()
-			Expect(d).NotTo(BeNil())
+			for _, standardTracker := range []bool{true, false} {
+				d := createTracker(standardTracker)
+				Expect(d).NotTo(BeNil())
 
-			sleeperJob.RemoteCommand = "/bin/bash"
-			sleeperJob.Args = []string{"-c", `exit 1`}
-			jobID, err := d.AddJob(sleeperJob)
-			Expect(err).To(BeNil())
-			Expect(jobID).NotTo(Equal(""))
+				sleeperJob.RemoteCommand = "/bin/bash"
+				sleeperJob.Args = []string{"-c", `exit 1`}
+				jobID, err := d.AddJob(sleeperJob)
+				Expect(err).To(BeNil())
+				Expect(jobID).NotTo(Equal(""))
 
-			err = d.Wait(jobID, time.Second*31, drmaa2interface.Done, drmaa2interface.Failed)
-			Expect(err).To(BeNil())
+				err = d.Wait(jobID, time.Second*31, drmaa2interface.Done, drmaa2interface.Failed)
+				Expect(err).To(BeNil())
 
-			state, substate, err := d.JobState(jobID)
-			Expect(err).To(BeNil())
-			Expect(substate).To(Equal(""))
-			// job was running through even there was exit code of 1
-			Expect(state.String()).To(Equal(drmaa2interface.Done.String()))
+				state, substate, err := d.JobState(jobID)
+				Expect(err).To(BeNil())
+				Expect(substate).To(Equal(""))
+				// job was running through even there was exit code of 1
+				Expect(state.String()).To(Equal(drmaa2interface.Done.String()))
 
-			jobInfo, err := d.JobInfo(jobID)
-			Expect(err).To(BeNil())
-			Expect(jobInfo.ID).To(Equal(jobID))
-			Expect(jobInfo.ExitStatus).To(BeNumerically("==", 1))
-			Expect(jobInfo.State.String()).To(Equal(drmaa2interface.Failed.String()))
+				jobInfo, err := d.JobInfo(jobID)
+				Expect(err).To(BeNil())
+				Expect(jobInfo.ID).To(Equal(jobID))
+				Expect(jobInfo.ExitStatus).To(BeNumerically("==", 1))
+				Expect(jobInfo.State.String()).To(Equal(drmaa2interface.Failed.String()))
+
+				d.DestroySession()
+			}
 		})
 
 		It("should mark a job as failed when it can't be executed", func() {
-			d, err := NewDRMAATracker()
-			Expect(err).To(BeNil())
-			defer d.DestroySession()
-			Expect(d).NotTo(BeNil())
+			for _, standardTracker := range []bool{true, false} {
+				d := createTracker(standardTracker)
+				Expect(d).NotTo(BeNil())
 
-			sleeperJob.RemoteCommand = "/binary/notfound"
-			jobID, err := d.AddJob(sleeperJob)
-			Expect(err).To(BeNil())
-			Expect(jobID).NotTo(Equal(""))
+				sleeperJob.RemoteCommand = "/binary/notfound"
+				jobID, err := d.AddJob(sleeperJob)
+				Expect(err).To(BeNil())
+				Expect(jobID).NotTo(Equal(""))
 
-			err = d.Wait(jobID, time.Second*31, drmaa2interface.Done, drmaa2interface.Failed)
-			Expect(err).To(BeNil())
+				err = d.Wait(jobID, time.Second*31, drmaa2interface.Done, drmaa2interface.Failed)
+				Expect(err).To(BeNil())
 
-			state, substate, err := d.JobState(jobID)
-			Expect(err).To(BeNil())
-			Expect(substate).To(Equal(""))
-			Expect(state.String()).To(Equal(drmaa2interface.Failed.String()))
+				state, substate, err := d.JobState(jobID)
+				Expect(err).To(BeNil())
+				Expect(substate).To(Equal(""))
+				Expect(state.String()).To(Equal(drmaa2interface.Failed.String()))
 
-			jobInfo, err := d.JobInfo(jobID)
-			Expect(err).To(BeNil())
-			Expect(jobInfo.ID).To(Equal(jobID))
-			Expect(jobInfo.State.String()).To(Equal(drmaa2interface.Failed.String()))
-			// jobInfo.SubState --
+				jobInfo, err := d.JobInfo(jobID)
+				Expect(err).To(BeNil())
+				Expect(jobInfo.ID).To(Equal(jobID))
+				Expect(jobInfo.State.String()).To(Equal(drmaa2interface.Failed.String()))
+				// jobInfo.SubState --
+
+				d.DestroySession()
+			}
 		})
 
 	})
@@ -154,42 +188,44 @@ var _ = Describe("Tracker", func() {
 	Context("Job lifecyle management", func() {
 
 		It("should wait until a job is running, suspend, resume and kill it", func() {
-			d, err := NewDRMAATracker()
-			Expect(err).To(BeNil())
-			defer d.DestroySession()
-			Expect(d).NotTo(BeNil())
+			for _, standardTracker := range []bool{true, false} {
+				d := createTracker(standardTracker)
+				Expect(d).NotTo(BeNil())
 
-			sleeperJob.Args = []string{"120"}
+				sleeperJob.Args = []string{"120"}
 
-			jobID, err := d.AddJob(sleeperJob)
-			Expect(err).To(BeNil())
+				jobID, err := d.AddJob(sleeperJob)
+				Expect(err).To(BeNil())
 
-			err = d.Wait(jobID, time.Second*31, drmaa2interface.Running)
-			Expect(err).To(BeNil())
+				err = d.Wait(jobID, time.Second*31, drmaa2interface.Running)
+				Expect(err).To(BeNil())
 
-			err = d.JobControl(jobID, "suspend")
-			Expect(err).To(BeNil())
+				err = d.JobControl(jobID, "suspend")
+				Expect(err).To(BeNil())
 
-			state, _, err := d.JobState(jobID)
-			Expect(err).To(BeNil())
-			Expect(state.String()).To(Equal(drmaa2interface.Suspended.String()))
+				state, _, err := d.JobState(jobID)
+				Expect(err).To(BeNil())
+				Expect(state.String()).To(Equal(drmaa2interface.Suspended.String()))
 
-			err = d.JobControl(jobID, "resume")
-			Expect(err).To(BeNil())
+				err = d.JobControl(jobID, "resume")
+				Expect(err).To(BeNil())
 
-			state, _, err = d.JobState(jobID)
-			Expect(err).To(BeNil())
-			Expect(state.String()).To(Equal(drmaa2interface.Running.String()))
+				state, _, err = d.JobState(jobID)
+				Expect(err).To(BeNil())
+				Expect(state.String()).To(Equal(drmaa2interface.Running.String()))
 
-			err = d.JobControl(jobID, "terminate")
-			Expect(err).To(BeNil())
+				err = d.JobControl(jobID, "terminate")
+				Expect(err).To(BeNil())
 
-			err = d.Wait(jobID, time.Second*40, drmaa2interface.Done, drmaa2interface.Failed, drmaa2interface.Undetermined)
-			Expect(err).To(BeNil())
+				err = d.Wait(jobID, time.Second*40, drmaa2interface.Done, drmaa2interface.Failed, drmaa2interface.Undetermined)
+				Expect(err).To(BeNil())
 
-			state, _, err = d.JobState(jobID)
-			Expect(err).To(BeNil())
-			Expect(state.String()).To(Equal(drmaa2interface.Failed.String()))
+				state, _, err = d.JobState(jobID)
+				Expect(err).To(BeNil())
+				Expect(state.String()).To(Equal(drmaa2interface.Failed.String()))
+
+				d.DestroySession()
+			}
 		})
 
 	})
@@ -197,13 +233,15 @@ var _ = Describe("Tracker", func() {
 	Context("contact string", func() {
 
 		It("should return the contact string of the drmaa connection", func() {
-			d, err := NewDRMAATracker()
-			Expect(err).To(BeNil())
-			defer d.DestroySession()
+			for _, standardTracker := range []bool{true, false} {
+				d := createTracker(standardTracker)
 
-			c, err := d.Contact()
-			Expect(err).To(BeNil())
-			Expect(c).NotTo(Equal(""))
+				c, err := d.Contact()
+				Expect(err).To(BeNil())
+				Expect(c).NotTo(Equal(""))
+
+				d.DestroySession()
+			}
 		})
 
 	})
@@ -211,24 +249,26 @@ var _ = Describe("Tracker", func() {
 	Measure("it should submit jobs in a short time", func(b Benchmarker) {
 		<-time.Tick(time.Second * 5)
 
-		d, err := NewDRMAATracker()
-		Expect(err).To(BeNil())
-		defer d.DestroySession()
-		Expect(d).NotTo(BeNil())
+		for _, standardTracker := range []bool{true, false} {
+			d := createTracker(standardTracker)
+			Expect(d).NotTo(BeNil())
 
-		jobids := make([]string, 0, 16)
-		submissiontime := b.Time("submissiontime", func() {
-			jobid, _ := d.AddJob(sleeperJob)
-			jobids = append(jobids, jobid)
-		})
+			jobids := make([]string, 0, 16)
+			submissiontime := b.Time("submissiontime", func() {
+				jobid, _ := d.AddJob(sleeperJob)
+				jobids = append(jobids, jobid)
+			})
 
-		Expect(submissiontime.Seconds()).To(BeNumerically("<", 0.050), "Submitting a job shouldn't take longer than 3 ms in avg.")
+			Expect(submissiontime.Seconds()).To(BeNumerically("<", 0.050), "Submitting a job shouldn't take longer than 3 ms in avg.")
 
-		// clean up
-		for _, jobID := range jobids {
-			d.JobControl(jobID, "terminate")
+			// clean up
+			for _, jobID := range jobids {
+				d.JobControl(jobID, "terminate")
+			}
+			<-time.Tick(time.Second * 5)
+
+			d.DestroySession()
 		}
-		<-time.Tick(time.Second * 5)
 
 	}, 20)
 

--- a/pkg/jobtracker/libdrmaa/tracker_test.go
+++ b/pkg/jobtracker/libdrmaa/tracker_test.go
@@ -194,6 +194,20 @@ var _ = Describe("Tracker", func() {
 
 	})
 
+	Context("contact string", func() {
+
+		It("should return the contact string of the drmaa connection", func() {
+			d, err := NewDRMAATracker()
+			Expect(err).To(BeNil())
+			defer d.DestroySession()
+
+			c, err := d.Contact()
+			Expect(err).To(BeNil())
+			Expect(c).NotTo(Equal(""))
+		})
+
+	})
+
 	Measure("it should submit jobs in a short time", func(b Benchmarker) {
 		<-time.Tick(time.Second * 5)
 

--- a/pkg/jobtracker/libdrmaa/tracker_test.go
+++ b/pkg/jobtracker/libdrmaa/tracker_test.go
@@ -246,6 +246,30 @@ var _ = Describe("Tracker", func() {
 
 	})
 
+	Context("jobtracker with params", func() {
+
+		It("should error when param has wrong type", func() {
+			tracker, err := NewDRMAATrackerWithParams("string")
+			Expect(err).NotTo(BeNil())
+			Expect(tracker).To(BeNil())
+
+			// this should fail as it must not be a reference
+			tracker, err := NewDRMAATrackerWithParams(&LibDRMAASessionParams{})
+			Expect(err).NotTo(BeNil())
+			Expect(tracker).To(BeNil())
+		})
+
+		It("should error when param has wrong semantic", func() {
+			tracker, err := NewDRMAATrackerWithParams(LibDRMAASessionParams{
+				UsePersistentJobStorage: true,
+				DBFilePath:              "",
+			})
+			Expect(err).NotTo(BeNil())
+			Expect(tracker).To(BeNil())
+		})
+
+	})
+
 	Measure("it should submit jobs in a short time", func(b Benchmarker) {
 		<-time.Tick(time.Second * 5)
 

--- a/pkg/jobtracker/simpletracker/jobstore.go
+++ b/pkg/jobtracker/simpletracker/jobstore.go
@@ -3,9 +3,10 @@ package simpletracker
 import (
 	"errors"
 	"fmt"
-	"github.com/dgruber/drmaa2interface"
 	"strconv"
 	"strings"
+
+	"github.com/dgruber/drmaa2interface"
 )
 
 // JobStore is an internal storage for jobs and job templates

--- a/pkg/jobtracker/simpletracker/jobstore_test.go
+++ b/pkg/jobtracker/simpletracker/jobstore_test.go
@@ -1,6 +1,8 @@
 package simpletracker_test
 
 import (
+	"os"
+
 	. "github.com/dgruber/drmaa2os/pkg/jobtracker/simpletracker"
 
 	. "github.com/onsi/ginkgo"
@@ -13,162 +15,179 @@ var _ = Describe("Jobstore", func() {
 
 	Context("Basic JobStore operations", func() {
 
+		var inmemory *JobStore
+		var persistent *PersistentJobStorage
+
+		BeforeEach(func() {
+			inmemory = NewJobStore()
+			Ω(inmemory).ShouldNot(BeNil())
+
+			file, err := os.CreateTemp("", "jobstoretest")
+			Expect(err).To(BeNil())
+			name := file.Name()
+			file.Close()
+			persistent, err = NewPersistentJobStore(name)
+			Expect(err).To(BeNil())
+		})
+
 		It("should be possible to create a JobStore, save a job, and get the PID", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			store.SaveJob("13", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
-			store.SaveJob("1", drmaa2interface.JobTemplate{RemoteCommand: "rc2"}, 13)
-			store.SaveJob("12", drmaa2interface.JobTemplate{RemoteCommand: "rc3"}, 10)
-			pid, err := store.GetPID("12")
-			Ω(err).Should(BeNil())
-			Ω(pid).Should(BeNumerically("==", 10))
-			pid, err = store.GetPID("1")
-			Ω(err).Should(BeNil())
-			Ω(pid).Should(BeNumerically("==", 13))
-			pid, err = store.GetPID("13")
-			Ω(err).Should(BeNil())
-			Ω(pid).Should(BeNumerically("==", 77))
+
+			for _, store := range []JobStorer{persistent, inmemory} {
+				Ω(store).ShouldNot(BeNil())
+				store.SaveJob("13", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
+				store.SaveJob("1", drmaa2interface.JobTemplate{RemoteCommand: "rc2"}, 13)
+				store.SaveJob("12", drmaa2interface.JobTemplate{RemoteCommand: "rc3"}, 10)
+				pid, err := store.GetPID("12")
+				Ω(err).Should(BeNil())
+				Ω(pid).Should(BeNumerically("==", 10))
+				pid, err = store.GetPID("1")
+				Ω(err).Should(BeNil())
+				Ω(pid).Should(BeNumerically("==", 13))
+				pid, err = store.GetPID("13")
+				Ω(err).Should(BeNil())
+				Ω(pid).Should(BeNumerically("==", 77))
+			}
 		})
 
 		It("should find PID of array job task", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			store.SaveArrayJob("13",
-				[]int{77, 78, 79},
-				drmaa2interface.JobTemplate{RemoteCommand: "rc"},
-				1, 3, 1)
-			store.SaveJob("13.1", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
-			store.SaveJob("13.2", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 78)
-			store.SaveJob("13.3", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 79)
-			pid, err := store.GetPID("13.1")
-			Ω(err).Should(BeNil())
-			Ω(pid).Should(BeNumerically("==", 77))
-			pid, err = store.GetPID("13.2")
-			Ω(err).Should(BeNil())
-			Ω(pid).Should(BeNumerically("==", 78))
-			pid, err = store.GetPID("13.3")
-			Ω(err).Should(BeNil())
-			Ω(pid).Should(BeNumerically("==", 79))
+			for _, store := range []JobStorer{persistent, inmemory} {
+				store.SaveArrayJob("13",
+					[]int{77, 78, 79},
+					drmaa2interface.JobTemplate{RemoteCommand: "rc"},
+					1, 3, 1)
+				store.SaveJob("13.1", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
+				store.SaveJob("13.2", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 78)
+				store.SaveJob("13.3", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 79)
+				pid, err := store.GetPID("13.1")
+				Ω(err).Should(BeNil())
+				Ω(pid).Should(BeNumerically("==", 77))
+				pid, err = store.GetPID("13.2")
+				Ω(err).Should(BeNil())
+				Ω(pid).Should(BeNumerically("==", 78))
+				pid, err = store.GetPID("13.3")
+				Ω(err).Should(BeNil())
+				Ω(pid).Should(BeNumerically("==", 79))
+			}
 		})
 
 		It("should error when job is not found", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			pid, err := store.GetPID("12")
-			Ω(err).ShouldNot(BeNil())
-			Ω(pid).Should(BeNumerically("==", -1))
+			for _, store := range []JobStorer{persistent, inmemory} {
+				pid, err := store.GetPID("12")
+				Ω(err).ShouldNot(BeNil())
+				Ω(pid).Should(BeNumerically("==", -1))
+			}
 		})
 
 		It("should error when job id is wrong", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			pid, err := store.GetPID("12.asdf")
-			Ω(err).ShouldNot(BeNil())
-			Ω(pid).Should(BeNumerically("==", -1))
-			pid, err = store.GetPID("..")
-			Ω(err).ShouldNot(BeNil())
-			Ω(pid).Should(BeNumerically("==", -1))
-			store.SaveJob("13.2", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
-			pid, err = store.GetPID("13.asdf")
-			Ω(err).ShouldNot(BeNil())
-			Ω(pid).Should(BeNumerically("==", -1))
+			for _, store := range []JobStorer{persistent, inmemory} {
+				pid, err := store.GetPID("12.asdf")
+				Ω(err).ShouldNot(BeNil())
+				Ω(pid).Should(BeNumerically("==", -1))
+				pid, err = store.GetPID("..")
+				Ω(err).ShouldNot(BeNil())
+				Ω(pid).Should(BeNumerically("==", -1))
+				store.SaveJob("13.2", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
+				pid, err = store.GetPID("13.asdf")
+				Ω(err).ShouldNot(BeNil())
+				Ω(pid).Should(BeNumerically("==", -1))
+			}
 		})
 
 		It("should error when task is not found", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			store.SaveJob("13.1", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
-			pid, err := store.GetPID("13.77")
-			Ω(err).ShouldNot(BeNil())
-			Ω(pid).Should(BeNumerically("==", -1))
-			pid, err = store.GetPID("13.abc")
-			Ω(err).ShouldNot(BeNil())
-			Ω(pid).Should(BeNumerically("==", -1))
+			for _, store := range []JobStorer{persistent, inmemory} {
+				store.SaveJob("13.1", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
+				pid, err := store.GetPID("13.77")
+				Ω(err).ShouldNot(BeNil())
+				Ω(pid).Should(BeNumerically("==", -1))
+				pid, err = store.GetPID("13.abc")
+				Ω(err).ShouldNot(BeNil())
+				Ω(pid).Should(BeNumerically("==", -1))
+			}
 		})
 
 		It("should error when task is not found", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			store.SaveArrayJob("13",
-				[]int{77, 78, 79},
-				drmaa2interface.JobTemplate{RemoteCommand: "rc"},
-				1, 3, 1)
-			pid, err := store.GetPID("13.10")
-			Ω(err).ShouldNot(BeNil())
-			Ω(pid).Should(BeNumerically("==", -1))
-			pid, err = store.GetPID("13.abc")
-			Ω(err).ShouldNot(BeNil())
-			Ω(pid).Should(BeNumerically("==", -1))
+			for _, store := range []JobStorer{persistent, inmemory} {
+				store.SaveArrayJob("13",
+					[]int{77, 78, 79},
+					drmaa2interface.JobTemplate{RemoteCommand: "rc"},
+					1, 3, 1)
+				pid, err := store.GetPID("13.10")
+				Ω(err).ShouldNot(BeNil())
+				Ω(pid).Should(BeNumerically("==", -1))
+				pid, err = store.GetPID("13.abc")
+				Ω(err).ShouldNot(BeNil())
+				Ω(pid).Should(BeNumerically("==", -1))
+			}
 		})
 
 		It("should save and delete a job array", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			store.SaveJob("77.2", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
-			store.SaveArrayJob("13",
-				[]int{77, 78, 79},
-				drmaa2interface.JobTemplate{RemoteCommand: "rc"},
-				1, 3, 1)
-			Ω(store.HasJob("13.1")).Should(BeTrue())
-			Ω(store.HasJob("13.2")).Should(BeTrue())
-			Ω(store.HasJob("13.3")).Should(BeTrue())
-			store.RemoveJob("13.2")
-			Ω(store.HasJob("13.2")).Should(BeFalse())
-			store.RemoveJob("13")
-			Ω(store.HasJob("13.1")).Should(BeFalse())
-			Ω(store.HasJob("13.3")).Should(BeFalse())
+			for _, store := range []JobStorer{persistent, inmemory} {
+				store.SaveJob("77.2", drmaa2interface.JobTemplate{RemoteCommand: "rc"}, 77)
+				store.SaveArrayJob("13",
+					[]int{77, 78, 79},
+					drmaa2interface.JobTemplate{RemoteCommand: "rc"},
+					1, 3, 1)
+				Ω(store.HasJob("13.1")).Should(BeTrue())
+				Ω(store.HasJob("13.2")).Should(BeTrue())
+				Ω(store.HasJob("13.3")).Should(BeTrue())
+				store.RemoveJob("13.2")
+				Ω(store.HasJob("13.2")).Should(BeFalse())
+				store.RemoveJob("13")
+				Ω(store.HasJob("13.1")).Should(BeFalse())
+				Ω(store.HasJob("13.3")).Should(BeFalse())
+			}
 		})
 
 		It("should save and a job array and add the PID of a task afterwards", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			store.SaveArrayJob("13",
-				[]int{0, 0, 0},
-				drmaa2interface.JobTemplate{RemoteCommand: "rc"},
-				1, 3, 1)
-			pid, err := store.GetPID("13.2")
-			Ω(err).Should(BeNil())
-			Ω(pid).Should(BeNumerically("==", 0))
+			for _, store := range []JobStorer{persistent, inmemory} {
+				store.SaveArrayJob("13",
+					[]int{0, 0, 0},
+					drmaa2interface.JobTemplate{RemoteCommand: "rc"},
+					1, 3, 1)
+				pid, err := store.GetPID("13.2")
+				Ω(err).Should(BeNil())
+				Ω(pid).Should(BeNumerically("==", 0))
 
-			err = store.SaveArrayJobPID("13", 2, 77)
-			Ω(err).Should(BeNil())
-			pid, err = store.GetPID("13.2")
-			Ω(err).Should(BeNil())
-			Ω(pid).Should(BeNumerically("==", 77))
+				err = store.SaveArrayJobPID("13", 2, 77)
+				Ω(err).Should(BeNil())
+				pid, err = store.GetPID("13.2")
+				Ω(err).Should(BeNil())
+				Ω(pid).Should(BeNumerically("==", 77))
 
-			err = store.SaveArrayJobPID("13", 50, 77)
-			Ω(err).ShouldNot(BeNil())
+				err = store.SaveArrayJobPID("13", 50, 77)
+				Ω(err).ShouldNot(BeNil())
 
-			err = store.SaveArrayJobPID("50", 50, 77)
-			Ω(err).ShouldNot(BeNil())
+				err = store.SaveArrayJobPID("50", 50, 77)
+				Ω(err).ShouldNot(BeNil())
+			}
 		})
 
 		It("should return the task IDs of an array job", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			store.SaveArrayJob("112",
-				[]int{0, 0, 0}, // no pid
-				drmaa2interface.JobTemplate{RemoteCommand: "rc"},
-				1, 3, 1)
-			tasks := store.GetArrayJobTaskIDs("112")
-			Ω(len(tasks)).To(BeNumerically("==", 3))
-			Ω(tasks[0]).To(Equal("112.1"))
-			Ω(tasks[1]).To(Equal("112.2"))
-			Ω(tasks[2]).To(Equal("112.3"))
+			for _, store := range []JobStorer{persistent, inmemory} {
+				store.SaveArrayJob("112",
+					[]int{0, 0, 0}, // no pid
+					drmaa2interface.JobTemplate{RemoteCommand: "rc"},
+					1, 3, 1)
+				tasks := store.GetArrayJobTaskIDs("112")
+				Ω(len(tasks)).To(BeNumerically("==", 3))
+				Ω(tasks[0]).To(Equal("112.1"))
+				Ω(tasks[1]).To(Equal("112.2"))
+				Ω(tasks[2]).To(Equal("112.3"))
+			}
 		})
 
 		It("should return the task IDs of an array job as job IDs", func() {
-			store := NewJobStore()
-			Ω(store).ShouldNot(BeNil())
-			store.SaveArrayJob("112",
-				[]int{0, 0, 0}, // no pid
-				drmaa2interface.JobTemplate{RemoteCommand: "rc"},
-				1, 3, 1)
-			tasks := store.GetJobIDs()
-			Ω(len(tasks)).To(BeNumerically("==", 3))
-			Ω(tasks[0]).To(Equal("112.1"))
-			Ω(tasks[1]).To(Equal("112.2"))
-			Ω(tasks[2]).To(Equal("112.3"))
+			for _, store := range []JobStorer{persistent, inmemory} {
+				store.SaveArrayJob("112",
+					[]int{0, 0, 0}, // no pid
+					drmaa2interface.JobTemplate{RemoteCommand: "rc"},
+					1, 3, 1)
+				tasks := store.GetJobIDs()
+				Ω(len(tasks)).To(BeNumerically("==", 3))
+				Ω(tasks).To(ContainElement("112.1"))
+				Ω(tasks).To(ContainElement("112.2"))
+				Ω(tasks).To(ContainElement("112.3"))
+			}
 		})
 
 	})

--- a/pkg/jobtracker/simpletracker/jobstorer.go
+++ b/pkg/jobtracker/simpletracker/jobstorer.go
@@ -1,0 +1,17 @@
+package simpletracker
+
+import (
+	"github.com/dgruber/drmaa2interface"
+)
+
+// JobStorer has all methods required for storing job related information.
+type JobStorer interface {
+	SaveJob(jobid string, t drmaa2interface.JobTemplate, pid int)
+	HasJob(jobid string) bool
+	RemoveJob(jobid string)
+	SaveArrayJob(arrayjobid string, pids []int, t drmaa2interface.JobTemplate, begin, end, step int)
+	SaveArrayJobPID(arrayjobid string, taskid, pid int) error
+	GetPID(jobid string) (int, error)
+	GetJobIDs() []string
+	GetArrayJobTaskIDs(arrayjobID string) []string
+}

--- a/pkg/jobtracker/simpletracker/jobstorerpersistent.go
+++ b/pkg/jobtracker/simpletracker/jobstorerpersistent.go
@@ -1,0 +1,460 @@
+package simpletracker
+
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dgruber/drmaa2interface"
+	bolt "go.etcd.io/bbolt"
+)
+
+const JobIDsStorageKey string = "JobIDsStorageKey"
+const JobTemplatesStorageKey string = "JobTemplatesStorageKey"
+const JobStorageKey string = "JobStorageKey"
+const IsArrayJobStorageKey string = "IsArrayJobStorageKey"
+
+// PersistentJobStorage is an internal storage for jobs and job templates
+// processed by the job tracker. Jobs are stored until Reap().
+// Locking must be done externally.
+type PersistentJobStorage struct {
+	//jobsession string
+	// path to the DB file
+	path string
+	//
+	db *bolt.DB
+}
+
+// NewPersistentJobStore returns a new job store which uses a file based DB
+// to be persistent over process restarts. The PersistentJobStore implements
+// the JobStorer interface.
+func NewPersistentJobStore(path string) (*PersistentJobStorage, error) {
+	jobstore := &PersistentJobStorage{
+		//jobsession: jobsession,
+		path: path,
+	}
+
+	var err error
+	jobstore.db, err = bolt.Open(path, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		log.Fatal(err)
+		return nil, err
+	}
+
+	// ensure all buckets do exist
+	err = jobstore.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(JobIDsStorageKey))
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists([]byte(JobTemplatesStorageKey))
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists([]byte(JobStorageKey))
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists([]byte(IsArrayJobStorageKey))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	return jobstore, err
+}
+
+// SaveJob stores a job, the job submission template, and the process PID of
+// the job in an internal job store.
+func (js *PersistentJobStorage) SaveJob(jobid string, t drmaa2interface.JobTemplate, pid int) {
+
+	err := js.db.Update(func(tx *bolt.Tx) error {
+		db, err := tx.CreateBucketIfNotExists([]byte(JobIDsStorageKey))
+		if err != nil {
+			return err
+		}
+		err = db.Put([]byte(jobid), []byte(jobid))
+		if err != nil {
+			return fmt.Errorf("failed to save job: %v", err)
+		}
+
+		db, err = tx.CreateBucketIfNotExists([]byte(JobTemplatesStorageKey))
+		if err != nil {
+			return err
+		}
+		var buffer bytes.Buffer
+		enc := gob.NewEncoder(&buffer)
+		enc.Encode(t)
+		err = db.Put([]byte(jobid), buffer.Bytes())
+		if err != nil {
+			return fmt.Errorf("failed to save job: %v", err)
+		}
+
+		db, err = tx.CreateBucketIfNotExists([]byte(JobStorageKey))
+		if err != nil {
+			return err
+		}
+
+		var jobbuffer bytes.Buffer
+		enc = gob.NewEncoder(&jobbuffer)
+		enc.Encode([]InternalJob{{State: drmaa2interface.Running, PID: pid}})
+		err = db.Put([]byte(jobid), jobbuffer.Bytes())
+		if err != nil {
+			return fmt.Errorf("failed to save job: %v", err)
+		}
+
+		db, err = tx.CreateBucketIfNotExists([]byte(IsArrayJobStorageKey))
+		if err != nil {
+			return err
+		}
+		err = db.Put([]byte(jobid), []byte(fmt.Sprintf("%t", false)))
+		if err != nil {
+			return fmt.Errorf("failed to save job: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Printf("internal error: %v\n", err)
+	}
+}
+
+// HasJob returns true if the job is saved in the job store.
+func (js *PersistentJobStorage) HasJob(jobid string) bool {
+
+	err := js.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(JobTemplatesStorageKey))
+		if b == nil {
+			// not found
+			return fmt.Errorf("bucket with job templates not found")
+		}
+		template := b.Get([]byte(jobid))
+		if template == nil {
+			// not found, check in job list - might be an array job task
+			bjid := tx.Bucket([]byte(JobIDsStorageKey))
+			if bjid == nil {
+				return fmt.Errorf("bucket with job ids not found")
+			}
+			jid := bjid.Get([]byte(jobid))
+			if jid != nil {
+				return nil
+			}
+			return fmt.Errorf("jobid not found")
+		}
+		// job found
+		return nil
+
+	})
+
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// RemoveJob deletes all occurrences of a job within the job storage.
+// The jobid can be the identifier of a job or a job array. In case
+// of a job array it removes all tasks which belong to the array job.
+func (js *PersistentJobStorage) RemoveJob(jobid string) {
+
+	err := js.db.Update(func(tx *bolt.Tx) error {
+		// is array job?
+		db := tx.Bucket([]byte(IsArrayJobStorageKey))
+		if db == nil {
+			return fmt.Errorf("bucket with name %s not found", IsArrayJobStorageKey)
+		}
+		isArrayJob := false
+		isArrayJobDBEntry := db.Get([]byte(jobid))
+		if isArrayJobDBEntry != nil {
+			isArrayJob = true
+		}
+
+		// delete all relevant jobs from that DB
+		jobidsdb, err := tx.CreateBucketIfNotExists([]byte(JobIDsStorageKey))
+		if err != nil {
+			return err
+		}
+
+		if isArrayJob {
+			// delete all jobs with that prefix
+			// TODO optimize
+			for _, somejobid := range js.GetJobIDs() {
+				if strings.HasPrefix(somejobid, jobid+".") {
+					// delete jobid
+					err = jobidsdb.Delete([]byte(somejobid))
+					if err != nil {
+						return fmt.Errorf("failed to delete job %s: %v", somejobid, err)
+					}
+				}
+			}
+		} else {
+			// delete only job id
+			jobidsdb.Delete([]byte(jobid))
+		}
+
+		db, err = tx.CreateBucketIfNotExists([]byte(JobTemplatesStorageKey))
+		if err != nil {
+			return err
+		}
+		db.Delete([]byte(jobid))
+
+		db, err = tx.CreateBucketIfNotExists([]byte(JobStorageKey))
+		if err != nil {
+			return err
+		}
+		db.Delete([]byte(jobid))
+
+		db, err = tx.CreateBucketIfNotExists([]byte(IsArrayJobStorageKey))
+		if err != nil {
+			return err
+		}
+		db.Delete([]byte(jobid))
+
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("unexpected internal error while deleting job %s: %v\n", jobid, err)
+	}
+}
+
+func (js *PersistentJobStorage) saveJobTemplate(tx *bolt.Tx, jobid string, template drmaa2interface.JobTemplate) error {
+	db, err := tx.CreateBucketIfNotExists([]byte(JobTemplatesStorageKey))
+	if err != nil {
+		return err
+	}
+	var buffer bytes.Buffer
+	enc := gob.NewEncoder(&buffer)
+	enc.Encode(template)
+	err = db.Put([]byte(jobid), buffer.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to save job: %v", err)
+	}
+	return nil
+}
+
+func (js *PersistentJobStorage) saveIsArrayJobID(tx *bolt.Tx, jobid string, isArrayJob bool) error {
+	db, err := tx.CreateBucketIfNotExists([]byte(IsArrayJobStorageKey))
+	if err != nil {
+		return err
+	}
+	err = db.Put([]byte(jobid), []byte(fmt.Sprintf("%t", isArrayJob)))
+	if err != nil {
+		return fmt.Errorf("failed to save array job flag: %v", err)
+	}
+	return nil
+}
+
+func (js *PersistentJobStorage) saveInternalJobs(tx *bolt.Tx, jobid string, internalJobs []InternalJob) error {
+	db, err := tx.CreateBucketIfNotExists([]byte(JobStorageKey))
+	if err != nil {
+		return err
+	}
+	var jobbuffer bytes.Buffer
+	enc := gob.NewEncoder(&jobbuffer)
+	err = enc.Encode(internalJobs)
+	if err != nil {
+		return fmt.Errorf("failed to encode internal jobs: %v", err)
+	}
+	err = db.Put([]byte(jobid), jobbuffer.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to save job: %v", err)
+	}
+	return nil
+}
+
+func (js *PersistentJobStorage) getInternalJobs(tx *bolt.Tx, jobid string) ([]InternalJob, error) {
+	db := tx.Bucket([]byte(JobStorageKey))
+	if db == nil {
+		return nil, fmt.Errorf("bucket %s does not exist", JobStorageKey)
+	}
+	jobs := db.Get([]byte(jobid))
+	if jobs == nil {
+		return nil, errors.New("Job does not exist")
+	}
+	buffer := bytes.NewBuffer(jobs)
+	dec := gob.NewDecoder(buffer)
+	var internalJobs []InternalJob
+	err := dec.Decode(&internalJobs)
+	return internalJobs, err
+}
+
+func (js *PersistentJobStorage) saveJobID(tx *bolt.Tx, jobid string) error {
+	db, err := tx.CreateBucketIfNotExists([]byte(JobIDsStorageKey))
+	if err != nil {
+		return err
+	}
+	err = db.Put([]byte(jobid), []byte(jobid))
+	if err != nil {
+		return fmt.Errorf("failed to save job: %v", err)
+	}
+	return nil
+}
+
+// SaveArrayJob stores all process IDs of the tasks of an array job.
+func (js *PersistentJobStorage) SaveArrayJob(arrayjobid string, pids []int,
+	t drmaa2interface.JobTemplate, begin, end, step int) {
+	pid := 0
+
+	js.db.Update(func(tx *bolt.Tx) error {
+		err := js.saveJobTemplate(tx, arrayjobid, t)
+		if err != nil {
+			return err
+		}
+
+		err = js.saveIsArrayJobID(tx, arrayjobid, true)
+		if err != nil {
+			return err
+		}
+
+		internalJobs := make([]InternalJob, 0)
+
+		for i := begin; i <= end; i += step {
+			jobid := fmt.Sprintf("%s.%d", arrayjobid, i)
+
+			err = js.saveJobID(tx, jobid)
+			if err != nil {
+				return err
+			}
+
+			internalJobs = append(internalJobs,
+				InternalJob{
+					TaskID: i,
+					State:  drmaa2interface.Queued,
+					PID:    pids[pid],
+				})
+			pid++
+		}
+		return js.saveInternalJobs(tx, arrayjobid, internalJobs)
+	})
+
+}
+
+// SaveArrayJobPID stores the current PID of main process of the
+// job array task.
+func (js *PersistentJobStorage) SaveArrayJobPID(arrayjobid string, taskid, pid int) error {
+	return js.db.Update(func(tx *bolt.Tx) error {
+		internalJobs, err := js.getInternalJobs(tx, arrayjobid)
+		if err != nil {
+			return fmt.Errorf("could not get internal jobs for array job id %s: %v",
+				arrayjobid, err)
+		}
+		for task := range internalJobs {
+			if internalJobs[task].TaskID == taskid {
+				internalJobs[task].PID = pid
+				internalJobs[task].State = drmaa2interface.Running
+				return js.saveInternalJobs(tx, arrayjobid, internalJobs)
+			}
+		}
+		return errors.New("task not found")
+	})
+}
+
+// GetPID returns the PID of a job or an array job task.
+// It returns -1 and an error if the job is not known.
+func (js *PersistentJobStorage) GetPID(jobid string) (int, error) {
+	jobelements := strings.Split(jobid, ".")
+	var jobidint int
+
+	err := js.db.View(func(tx *bolt.Tx) error {
+		job, err := js.getInternalJobs(tx, jobelements[0])
+		if err != nil {
+			return fmt.Errorf("Error getting job %s: %v",
+				jobelements[0], err)
+		}
+		var (
+			taskid int
+		)
+		if len(jobelements) > 1 {
+			// is array job
+			taskid, err = strconv.Atoi(jobelements[1])
+			if err != nil {
+				return errors.New("TaskID within job ID is not a number")
+			}
+		}
+		if taskid == 0 || taskid == 1 {
+			jobidint = job[0].PID
+			return nil
+		}
+		for task := range job {
+			if job[task].TaskID == taskid {
+				jobidint = job[task].PID
+				return nil
+			}
+		}
+		return errors.New("TaskID not found in job array")
+	})
+
+	if err != nil {
+		return -1, err
+	}
+
+	return jobidint, nil
+}
+
+// GetJobIDs returns the IDs of all jobs.
+func (js *PersistentJobStorage) GetJobIDs() []string {
+	/*
+		tmp := make([]string, len(js.jobids), len(js.jobids))
+		copy(tmp, js.jobids)
+		return tmp
+	*/
+	var jobs sync.Map
+	err := js.db.View(func(tx *bolt.Tx) error {
+		db := tx.Bucket([]byte(JobIDsStorageKey))
+		if db == nil {
+			return fmt.Errorf("bucket %s does not exist", JobIDsStorageKey)
+		}
+		db.ForEach(func(k []byte, v []byte) error {
+			jobs.Store(string(k), string(v))
+			return nil
+		})
+		return nil
+	})
+	if err != nil {
+		log.Printf("internal error during getting job ids: %v", err)
+	}
+
+	jobids := make([]string, 0)
+	jobs.Range(func(k interface{}, v interface{}) bool {
+		jobids = append(jobids, k.(string))
+		return true
+	})
+
+	return jobids
+}
+
+// GetArrayJobTaskIDs returns the IDs of all tasks of a job array.
+func (js *PersistentJobStorage) GetArrayJobTaskIDs(arrayjobID string) []string {
+	/*
+		jobids := make([]string, 0, len(js.jobs[arrayjobID]))
+		for _, job := range js.jobs[arrayjobID] {
+			jobids = append(jobids, fmt.Sprintf("%s.%d", arrayjobID, job.TaskID))
+		}
+		return jobids
+	*/
+	jobids := make([]string, 0)
+	err := js.db.View(func(tx *bolt.Tx) error {
+		internalJobs, err := js.getInternalJobs(tx, arrayjobID)
+		if err != nil {
+			return err
+		}
+		for _, job := range internalJobs {
+			jobids = append(jobids, fmt.Sprintf("%s.%d", arrayjobID, job.TaskID))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil
+	}
+	// sort array jobs to have the same order as in memore store
+	sort.Strings(jobids)
+	return jobids
+}

--- a/pkg/jobtracker/simpletracker/jobstorerpersistent.go
+++ b/pkg/jobtracker/simpletracker/jobstorerpersistent.go
@@ -44,7 +44,7 @@ func NewPersistentJobStore(path string) (*PersistentJobStorage, error) {
 	var err error
 	jobstore.db, err = bolt.Open(path, 0600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to initialized boltdb for job storage: %v\n", err)
 		return nil, err
 	}
 

--- a/pkg/jobtracker/simpletracker/jobstorerpersistent.go
+++ b/pkg/jobtracker/simpletracker/jobstorerpersistent.go
@@ -332,7 +332,11 @@ func (js *PersistentJobStorage) SaveArrayJob(arrayjobid string, pids []int,
 				})
 			pid++
 		}
-		return js.saveInternalJobs(tx, arrayjobid, internalJobs)
+		err = js.saveInternalJobs(tx, arrayjobid, internalJobs)
+		if err != nil {
+			return err
+		}
+		return nil
 	})
 
 }
@@ -350,7 +354,11 @@ func (js *PersistentJobStorage) SaveArrayJobPID(arrayjobid string, taskid, pid i
 			if internalJobs[task].TaskID == taskid {
 				internalJobs[task].PID = pid
 				internalJobs[task].State = drmaa2interface.Running
-				return js.saveInternalJobs(tx, arrayjobid, internalJobs)
+				err = js.saveInternalJobs(tx, arrayjobid, internalJobs)
+				if err != nil {
+					return err
+				}
+				return nil
 			}
 		}
 		return errors.New("task not found")

--- a/pkg/jobtracker/simpletracker/simpletracker_test.go
+++ b/pkg/jobtracker/simpletracker/simpletracker_test.go
@@ -228,9 +228,6 @@ var _ = Describe("Simpletracker", func() {
 
 			err = tracker.DeleteJob(jobid)
 			Ω(err).ShouldNot(BeNil())
-
-			_, err = tracker.JobInfo(jobid)
-			Ω(err).ShouldNot(BeNil())
 		})
 
 		It("must return an undetermined state for a non-existing job", func() {

--- a/pkg/storage/boltstore/boltstore.go
+++ b/pkg/storage/boltstore/boltstore.go
@@ -2,10 +2,11 @@ package boltstore
 
 import (
 	"errors"
-	"github.com/dgruber/drmaa2os/pkg/storage"
-	bolt "go.etcd.io/bbolt"
 	"log"
 	"time"
+
+	"github.com/dgruber/drmaa2os/pkg/storage"
+	bolt "go.etcd.io/bbolt"
 )
 
 func NewBoltStore(path string) storage.Storer {
@@ -39,7 +40,11 @@ func (b *BoltStore) Put(t storage.KeyType, key, value string) error {
 		if err != nil {
 			return err
 		}
-		return b.Put([]byte(key), []byte(value))
+		err = b.Put([]byte(key), []byte(value))
+		if err != nil {
+			return err
+		}
+		return nil
 	})
 }
 
@@ -92,15 +97,19 @@ func (b *BoltStore) Delete(t storage.KeyType, key string) error {
 		if b.Get([]byte(key)) == nil {
 			return errors.New("it does not exist")
 		}
-		return b.Delete([]byte(key))
+		err := b.Delete([]byte(key))
+		if err != nil {
+			return err
+		}
+		return nil
 	})
 }
 
 func (b *BoltStore) Exists(t storage.KeyType, key string) bool {
-	if value, err := b.Get(t, key); err == nil {
-		if value != "" {
-			return true
-		}
+	if _, err := b.Get(t, key); err == nil {
+		//		if value != "" {
+		return true
+		//		}
 	}
 	return false
 }

--- a/pkg/storage/boltstore/boltstore.go
+++ b/pkg/storage/boltstore/boltstore.go
@@ -22,7 +22,7 @@ func (b *BoltStore) Init() error {
 	var err error
 	b.db, err = bolt.Open(b.dbfile, 0600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to initialized boltdb: %v\n", err)
 	}
 	return err
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Store", func() {
 			exists3 := store.Exists(JobSessionType, "keyX")
 			Expect(exists3).Should(BeFalse())
 
-			exists4 := store.Exists(JobSessionType, "key3", "")
+			exists4 := store.Exists(JobSessionType, "key3")
 			Expect(exists4).To(BeTrue())
 		})
 	})

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -133,17 +133,20 @@ var _ = Describe("Store", func() {
 			Expect(errPut1).To(BeNil())
 			errPut2 := store.Put(JobSessionType, "key2", "value2")
 			Expect(errPut2).To(BeNil())
-			errPut3 := store.Put(JobSessionType, "key3", "value3")
+			errPut3 := store.Put(JobSessionType, "key3", "")
 			Expect(errPut3).To(BeNil())
 
 			exists := store.Exists(JobSessionType, "key2")
-			Ω(exists).Should(BeTrue())
+			Expect(exists).Should(BeTrue())
 
 			exists2 := store.Exists(ReservationSessionType, "key2")
-			Ω(exists2).Should(BeFalse())
+			Expect(exists2).Should(BeFalse())
 
 			exists3 := store.Exists(JobSessionType, "keyX")
-			Ω(exists3).Should(BeFalse())
+			Expect(exists3).Should(BeFalse())
+
+			exists4 := store.Exists(JobSessionType, "key3", "")
+			Expect(exists4).To(BeTrue())
 		})
 	})
 

--- a/sessionmanager.go
+++ b/sessionmanager.go
@@ -240,7 +240,7 @@ func (sm *SessionManager) OpenJobSession(name string) (drmaa2interface.JobSessio
 				name, err)
 		}
 		log.Printf("using internal DRMAA job session %s with contact string %s\n", name, contact)
-		err = TryToSetContactString(&createParams, contact)
+		err = TryToSetContactString(createParams, contact)
 		if err != nil {
 			return nil, fmt.Errorf("could not set new contact string for opening job session %s: %v",
 				name, err)

--- a/sessionmanager.go
+++ b/sessionmanager.go
@@ -197,13 +197,14 @@ func (sm *SessionManager) CreateJobSession(name, contact string) (drmaa2interfac
 	js := newJobSession(name, []jobtracker.JobTracker{jt})
 
 	// for libdrmaa return contact string and store it for open job session
-	if sm.sessionType == LibDRMAASession {
+	if sm.sessionType == LibDRMAASession && sm.jobTrackerCreateParams != nil {
 		if contactStringer, ok := jt.(jobtracker.ContactStringer); ok {
 			contact, err := contactStringer.Contact()
 			if err != nil {
 				return nil, fmt.Errorf("Failed to get contact string after session creation: %v", err)
 			}
 			// store new contact string for job session
+			fmt.Printf("saving contact string %s\n", contact)
 			sm.store.Put(storage.JobSessionType, name, contact)
 		}
 	}
@@ -239,8 +240,8 @@ func (sm *SessionManager) OpenJobSession(name string) (drmaa2interface.JobSessio
 			return nil, fmt.Errorf("could not get contact string for job session: %s: %v",
 				name, err)
 		}
-		log.Printf("using internal DRMAA job session %s with contact string %s\n", name, contact)
-		err = TryToSetContactString(createParams, contact)
+		log.Printf("using internal DRMAA job session %s with contact string %s from DB\n", name, contact)
+		err = TryToSetContactString(&createParams, contact)
 		if err != nil {
 			return nil, fmt.Errorf("could not set new contact string for opening job session %s: %v",
 				name, err)

--- a/sessionmanager.go
+++ b/sessionmanager.go
@@ -233,14 +233,14 @@ func (sm *SessionManager) OpenJobSession(name string) (drmaa2interface.JobSessio
 
 	// restore contact string from storage and set it as ContactString
 	// in job tracker create params
-	if sm.sessionType == LibDRMAASession {
+	if sm.sessionType == LibDRMAASession && createParams != nil {
 		contact, err := sm.store.Get(storage.JobSessionType, name)
 		if err != nil {
 			return nil, fmt.Errorf("could not get contact string for job session: %s: %v",
 				name, err)
 		}
 		log.Printf("using internal DRMAA job session %s with contact string %s\n", name, contact)
-		err = TryToSetContactString(createParams, contact)
+		err = TryToSetContactString(&createParams, contact)
 		if err != nil {
 			return nil, fmt.Errorf("could not set new contact string for opening job session %s: %v",
 				name, err)

--- a/sessionmanager.go
+++ b/sessionmanager.go
@@ -2,6 +2,8 @@ package drmaa2os
 
 import (
 	"errors"
+	"fmt"
+	"log"
 
 	"code.cloudfoundry.org/lager"
 
@@ -134,6 +136,18 @@ func NewLibDRMAASessionManager(dbpath string) (*SessionManager, error) {
 	return makeSessionManager(dbpath, LibDRMAASession)
 }
 
+// NewLibDRMAASessionManagerWithParams creates a Go DRMAA session manager
+// like NewLibDRMAASessionManager but with additional parameters. The
+// parameters must be of type _libdrmaa.LibDRMAASessionParams_.
+func NewLibDRMAASessionManagerWithParams(ds interface{}, dbpath string) (*SessionManager, error) {
+	sm, err := makeSessionManager(dbpath, LibDRMAASession)
+	if err != nil {
+		return sm, err
+	}
+	sm.jobTrackerCreateParams = ds
+	return sm, nil
+}
+
 // NewPodmanSessionManager creates a new session manager for Podman.
 // The first parameter is either nil for using defaults or must be
 // of type _podmantracker.PodmanTrackerParams_.
@@ -181,6 +195,19 @@ func (sm *SessionManager) CreateJobSession(name, contact string) (drmaa2interfac
 		return nil, err
 	}
 	js := newJobSession(name, []jobtracker.JobTracker{jt})
+
+	// for libdrmaa return contact string and store it for open job session
+	if sm.sessionType == LibDRMAASession {
+		if contactStringer, ok := jt.(jobtracker.ContactStringer); ok {
+			contact, err := contactStringer.Contact()
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get contact string after session creation: %v", err)
+			}
+			// store new contact string for job session
+			sm.store.Put(storage.JobSessionType, name, contact)
+		}
+	}
+
 	return js, nil
 }
 
@@ -200,7 +227,27 @@ func (sm *SessionManager) OpenJobSession(name string) (drmaa2interface.JobSessio
 	if exists := sm.store.Exists(storage.JobSessionType, name); !exists {
 		return nil, errors.New("JobSession does not exist")
 	}
-	jt, err := sm.newRegisteredJobTracker(name, sm.jobTrackerCreateParams)
+
+	// require a copy as it gets modified
+	createParams := sm.jobTrackerCreateParams
+
+	// restore contact string from storage and set it as ContactString
+	// in job tracker create params
+	if sm.sessionType == LibDRMAASession {
+		contact, err := sm.store.Get(storage.JobSessionType, name)
+		if err != nil {
+			return nil, fmt.Errorf("could not get contact string for job session: %s: %v",
+				name, err)
+		}
+		log.Printf("using internal DRMAA job session %s with contact string %s\n", name, contact)
+		err = TryToSetContactString(createParams, contact)
+		if err != nil {
+			return nil, fmt.Errorf("could not set new contact string for opening job session %s: %v",
+				name, err)
+		}
+	}
+
+	jt, err := sm.newRegisteredJobTracker(name, createParams)
 	if err != nil {
 		return nil, err
 	}

--- a/sessionmanager_hlp.go
+++ b/sessionmanager_hlp.go
@@ -79,9 +79,10 @@ func TryToSetContactString(createParams interface{}, contact string) error {
 		return fmt.Errorf("createParams is not pointer")
 	}
 	createStruct := ps.Elem()
-	if createStruct.Kind() != reflect.Struct {
-		return fmt.Errorf("createParams must be pointer to struct")
-	}
+	// it is an interface value...
+	//if createStruct.Kind() != reflect.Struct {
+	//	return fmt.Errorf("createParams must be pointer to struct")
+	//}
 	f := createStruct.FieldByName("ContactString")
 	if f.IsValid() {
 		if f.Kind() == reflect.String {

--- a/sessionmanager_hlp.go
+++ b/sessionmanager_hlp.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"sync"
 	"sync/atomic"
 
@@ -65,6 +66,35 @@ func (sm *SessionManager) create(t storage.KeyType, name string, contact string)
 func (sm *SessionManager) delete(t storage.KeyType, name string) error {
 	if err := sm.store.Delete(t, name); err != nil {
 		return sm.logErr("Error while deleting")
+	}
+	return nil
+}
+
+// TryToSetContactString sets the contact string in the job tracker
+// create params if create params has a contact string field.
+func TryToSetContactString(createParams interface{}, contact string) error {
+	// createParams must be pointer
+	ps := reflect.ValueOf(createParams)
+	if ps.Kind() != reflect.Ptr {
+		return fmt.Errorf("createParams is not pointer")
+	}
+	createStruct := ps.Elem()
+	if createStruct.Kind() != reflect.Struct {
+		return fmt.Errorf("createParams must be pointer to struct")
+	}
+	f := createStruct.FieldByName("ContactString")
+	if f.IsValid() {
+		if f.Kind() == reflect.String {
+			if f.CanSet() {
+				f.SetString(contact)
+			} else {
+				return fmt.Errorf("can't set ContactString of create params")
+			}
+		} else {
+			return fmt.Errorf("createParams has no ContactString value of kind string")
+		}
+	} else {
+		return fmt.Errorf("ContactString is not a valid field in createParams")
 	}
 	return nil
 }

--- a/sessionmanager_hlp.go
+++ b/sessionmanager_hlp.go
@@ -54,9 +54,9 @@ func (sm *SessionManager) create(t storage.KeyType, name string, contact string)
 	if exists := sm.store.Exists(t, name); exists {
 		return sm.logErr("Session already exists")
 	}
-	if contact == "" {
-		contact = name
-	}
+	//if contact == "" {
+	//	contact = name
+	//}
 	if err := sm.store.Put(t, name, contact); err != nil {
 		return err
 	}

--- a/sessionmanager_hlp_test.go
+++ b/sessionmanager_hlp_test.go
@@ -9,68 +9,73 @@ import (
 
 var _ = Describe("SessionmanagerHlp", func() {
 
-	FContext("reflect on ContactString in job tracker implementation specific params", func() {
+	Context("reflect on ContactString in job tracker implementation specific params", func() {
 
 		It("should set ContactString value", func() {
-			test := struct {
+			type X struct {
 				AnotherThing   int
 				ContactString  string
 				ContactString2 string
-			}{
+			}
+
+			var test interface{} = X{
 				AnotherThing:   11,
 				ContactString:  "",
 				ContactString2: "ö",
 			}
+
 			err := TryToSetContactString(&test, "ups")
 			Expect(err).To(BeNil())
-			Expect(test.ContactString).To(Equal("ups"))
-			Expect(test.AnotherThing).To(BeNumerically("==", 11))
-			Expect(test.ContactString2).To(Equal("ö"))
+			Expect(test.(X).ContactString).To(Equal("ups"))
+			Expect(test.(X).AnotherThing).To(BeNumerically("==", 11))
+			Expect(test.(X).ContactString2).To(Equal("ö"))
 
 			err = TryToSetContactString(&test, "fedex")
 			Expect(err).To(BeNil())
-			Expect(test.ContactString).To(Equal("fedex"))
-			Expect(test.AnotherThing).To(BeNumerically("==", 11))
-			Expect(test.ContactString2).To(Equal("ö"))
+			Expect(test.(X).ContactString).To(Equal("fedex"))
+			Expect(test.(X).AnotherThing).To(BeNumerically("==", 11))
+			Expect(test.(X).ContactString2).To(Equal("ö"))
 
 			err = TryToSetContactString(&test, "cat")
 			Expect(err).To(BeNil())
-			Expect(test.ContactString).To(Equal("cat"))
-			Expect(test.AnotherThing).To(BeNumerically("==", 11))
-			Expect(test.ContactString2).To(Equal("ö"))
+			Expect(test.(X).ContactString).To(Equal("cat"))
+			Expect(test.(X).AnotherThing).To(BeNumerically("==", 11))
+			Expect(test.(X).ContactString2).To(Equal("ö"))
 		})
 
 		It("should not crash if ContactString is not available", func() {
-			test := struct {
+			type X struct {
 				AnotherThing int
-			}{
+			}
+			var test interface{} = X{
 				AnotherThing: 11,
 			}
 			err := TryToSetContactString(&test, "∂")
-			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+			Expect(test.(X).AnotherThing).To(BeNumerically("==", 11))
 			Expect(err).NotTo(BeNil())
 			err = TryToSetContactString(nil, "k")
-			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+			Expect(test.(X).AnotherThing).To(BeNumerically("==", 11))
 			Expect(err).NotTo(BeNil())
 			err = TryToSetContactString(test, "k")
 			Expect(err).NotTo(BeNil())
-			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+			Expect(test.(X).AnotherThing).To(BeNumerically("==", 11))
 		})
 
 		It("should set ContactString when struct is referenced as interface", func() {
-			test := struct {
+			type X struct {
 				ContactString string
-			}{
+			}
+			test := X{
 				ContactString: "",
 			}
 			err := TryToSetContactString(&test, "∂")
-			Expect(test.ContactString).To(Equal("∂"))
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(BeNil())
+			Expect(test.ContactString).NotTo(Equal("∂"))
 
 			f := func(asInterface interface{}) {
-				err := TryToSetContactString(&test, "†")
-				Expect(test.ContactString).To(Equal("†"))
+				err := TryToSetContactString(&asInterface, "†")
 				Expect(err).To(BeNil())
+				Expect(asInterface.(X).ContactString).To(Equal("†"))
 			}
 			f(test)
 		})

--- a/sessionmanager_hlp_test.go
+++ b/sessionmanager_hlp_test.go
@@ -1,0 +1,62 @@
+package drmaa2os_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/dgruber/drmaa2os"
+)
+
+var _ = Describe("SessionmanagerHlp", func() {
+
+	Context("reflect on ContactString in job tracker implementation specific params", func() {
+
+		It("should set ContactString value", func() {
+			test := struct {
+				AnotherThing   int
+				ContactString  string
+				ContactString2 string
+			}{
+				AnotherThing:   11,
+				ContactString:  "",
+				ContactString2: "ö",
+			}
+			err := TryToSetContactString(&test, "ups")
+			Expect(err).To(BeNil())
+			Expect(test.ContactString).To(Equal("ups"))
+			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+			Expect(test.ContactString2).To(Equal("ö"))
+
+			err = TryToSetContactString(&test, "fedex")
+			Expect(err).To(BeNil())
+			Expect(test.ContactString).To(Equal("fedex"))
+			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+			Expect(test.ContactString2).To(Equal("ö"))
+
+			err = TryToSetContactString(&test, "cat")
+			Expect(err).To(BeNil())
+			Expect(test.ContactString).To(Equal("cat"))
+			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+			Expect(test.ContactString2).To(Equal("ö"))
+		})
+
+		It("should not crash if ContactString is not available", func() {
+			test := struct {
+				AnotherThing int
+			}{
+				AnotherThing: 11,
+			}
+			err := TryToSetContactString(&test, "∂")
+			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+			Expect(err).NotTo(BeNil())
+			err = TryToSetContactString(nil, "k")
+			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+			Expect(err).NotTo(BeNil())
+			err = TryToSetContactString(test, "k")
+			Expect(err).NotTo(BeNil())
+			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+		})
+
+	})
+
+})

--- a/sessionmanager_hlp_test.go
+++ b/sessionmanager_hlp_test.go
@@ -9,7 +9,7 @@ import (
 
 var _ = Describe("SessionmanagerHlp", func() {
 
-	Context("reflect on ContactString in job tracker implementation specific params", func() {
+	FContext("reflect on ContactString in job tracker implementation specific params", func() {
 
 		It("should set ContactString value", func() {
 			test := struct {
@@ -55,6 +55,24 @@ var _ = Describe("SessionmanagerHlp", func() {
 			err = TryToSetContactString(test, "k")
 			Expect(err).NotTo(BeNil())
 			Expect(test.AnotherThing).To(BeNumerically("==", 11))
+		})
+
+		It("should set ContactString when struct is referenced as interface", func() {
+			test := struct {
+				ContactString string
+			}{
+				ContactString: "",
+			}
+			err := TryToSetContactString(&test, "∂")
+			Expect(test.ContactString).To(Equal("∂"))
+			Expect(err).To(BeNil())
+
+			f := func(asInterface interface{}) {
+				err := TryToSetContactString(&test, "†")
+				Expect(test.ContactString).To(Equal("†"))
+				Expect(err).To(BeNil())
+			}
+			f(test)
 		})
 
 	})


### PR DESCRIPTION
- New drmaa2os.NewLibDRMAASessionManagerWithParams() allows to get contact string for job session to be stored and re-used transparaently. Has capability to store DRMAA1 jobs in DB file. 
- Allows to re-attach to the DRMAA1 session
- Solves #24