### PR TITLE
Add remote client / server example

### DIFF
--- a/examples/remote/client/client.go
+++ b/examples/remote/client/client.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
+	"github.com/dgruber/drmaa2interface"
+	"github.com/dgruber/drmaa2os"
+	"github.com/dgruber/drmaa2os/pkg/jobtracker/remote/client"
+	genclient "github.com/dgruber/drmaa2os/pkg/jobtracker/remote/client/generated"
+)
+
+func main() {
+	basicAuthProvider, err := securityprovider.NewSecurityProviderBasicAuth(
+		"user", "testpassword")
+	if err != nil {
+		panic(err)
+	}
+	sm, err := drmaa2os.NewRemoteSessionManager(client.ClientTrackerParams{
+		Server: "http://localhost:8088",
+		Path:   "/jobserver/jobmanagement",
+		Opts: []genclient.ClientOption{
+			genclient.WithRequestEditorFn(basicAuthProvider.Intercept),
+		},
+	}, "clientjobsession.db")
+	if err != nil {
+		panic(err)
+	}
+	js, err := sm.CreateJobSession("testjobsession", "")
+	if err != nil {
+		// job session exists
+		js, err = sm.OpenJobSession("testjobsession")
+		if err != nil {
+			panic(err)
+		}
+	}
+	fmt.Printf("Submitting sleep 10 job to remote server...\n")
+	job, err := js.RunJob(drmaa2interface.JobTemplate{
+		RemoteCommand: "sleep",
+		Args:          []string{"10"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	err = job.WaitTerminated(drmaa2interface.InfiniteTime)
+	if err != nil {
+		panic(err)
+	}
+	jobInfo, err := job.GetJobInfo()
+	if err != nil {
+		panic(err)
+	}
+	jsonFormat, err := json.Marshal(jobInfo)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("job info: %s\n", string(jsonFormat))
+}

--- a/examples/remote/server/server.go
+++ b/examples/remote/server/server.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/dgruber/drmaa2os/pkg/jobtracker"
+	"github.com/dgruber/drmaa2os/pkg/jobtracker/remote/server"
+	genserver "github.com/dgruber/drmaa2os/pkg/jobtracker/remote/server/generated"
+	"github.com/dgruber/drmaa2os/pkg/jobtracker/simpletracker"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func main() {
+	// run jobs behind server as simple OS processes
+	jobStore, err := simpletracker.NewPersistentJobStore("job.db")
+	if err != nil {
+		panic(err)
+	}
+	processTracker, err := simpletracker.NewWithJobStore(
+		"testsession", jobStore, true)
+	if err != nil {
+		panic(err)
+	}
+	RunServer(processTracker)
+}
+
+func RunServer(jobTracker jobtracker.JobTracker) {
+
+	// connect the OpenAPI spec with the job tracker
+	// interface implementation - could be anything
+	impl, _ := server.NewJobTrackerImpl(jobTracker)
+
+	// using chi router and logging + basic auth middleware
+	router := chi.NewRouter()
+	router.Use(middleware.Logger)
+	router.Use(middleware.BasicAuth("remotetracker",
+		map[string]string{
+			"user": "testpassword",
+		}))
+
+	// using the multiplexer for the case we want to serve
+	// different implemenations at the same server
+	m := http.NewServeMux()
+	m.Handle("/jobserver/jobmanagement/",
+		genserver.HandlerFromMuxWithBaseURL(
+			impl, router, "/jobserver/jobmanagement"))
+
+	// using standard http - this should be https with
+	// certificates
+	s := &http.Server{
+		Addr:           ":8088",
+		Handler:        m,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+	log.Fatal(s.ListenAndServe())
+}


### PR DESCRIPTION
Simple example of remote job submission through REST generated by the OpenAPI 3 spec.
The job backend can be any JobTracker implementation, here remote processes are 
executed.